### PR TITLE
Unit test fixes

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -29,7 +29,8 @@ import (
 var log = logf.Log.WithName("controller_clusterdeployment")
 
 const (
-	controllerName = "clusterdeployment"
+	controllerName                = "clusterdeployment"
+	ClusterDeploymentManagedLabel = "api.openshift.com/managed"
 )
 
 // Add creates a new ClusterDeployment Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -95,7 +96,7 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 	}
 
 	// Do not make certificate request if the cluster is not a Red Hat managed cluster.
-	if val, ok := cd.Labels["api.openshift.com/managed"]; ok {
+	if val, ok := cd.Labels[ClusterDeploymentManagedLabel]; ok {
 		if val != "true" {
 			reqLogger.Info("Not a managed cluster")
 			return reconcile.Result{}, nil

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -3,8 +3,9 @@ package clusterdeployment
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -229,6 +230,9 @@ func testClusterDeployment() *hivev1alpha1.ClusterDeployment {
 			Name:      testClusterName,
 			Namespace: testNamespace,
 			UID:       testUID,
+			Labels: map[string]string{
+				ClusterDeploymentManagedLabel: "true",
+			},
 		},
 		Spec: hivev1alpha1.ClusterDeploymentSpec{
 			BaseDomain:  testBaseDomain,


### PR DESCRIPTION
This PR adds the correct label to Cluster Deployments that are created for Red Hat managed clusters.