### PR TITLE
Bug fix: spawn UpdateMetrics as its own goroutine

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -120,7 +120,7 @@ func main() {
 
 	// Start metrics for prometheus
 	operatormetrics.StartMetrics()
-	operatormetrics.UpdateMetrics(hours)
+	go operatormetrics.UpdateMetrics(hours)
 	log.Info("Starting the Cmd.")
 
 	// Start the Cmd


### PR DESCRIPTION
Fixes a bug where the UpdateMetrics goes into an infinite loop in the main thread. 