### PR TITLE
Changed from Role/RoleBinding to ClusterRole/ClusterRoleBinding

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,8 +15,7 @@ spec:
       serviceAccountName: certman-operator
       containers:
         - name: certman-operator
-          # TODO Replace this with the built image name
-          image: quay.io/tparikh/test-operator
+          image: quay.io/app-sre/certman-operator
           command:
           - certman-operator
           imagePullPolicy: Always

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: certman-operator
@@ -45,3 +45,18 @@ rules:
   - certificaterequests
   verbs:
   - '*'
+- apiGroups:
+  - hive.openshift.io
+  attributeRestrictions: null
+  resources:
+  - clusterdeployments
+  - clusterdeployments/finalizers
+  - clusterdeployments/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+
+

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,11 +1,12 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: certman-operator
 subjects:
 - kind: ServiceAccount
   name: certman-operator
+  namespace: certman-operator
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: certman-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: certman-operator
+  namespace: certman-operator


### PR DESCRIPTION
This PR updates the Role to be a ClusterRole and RoleBinding to be ClusterRoleBinding. Role now grants permission to the hive.openshift.io api groups and clusterdeployments resources.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>