### PR TITLE
Don't create certificaterequest if domain list is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Let's Encrypt Certificate Management Operator
 
+
+

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -122,6 +122,7 @@ func (r *ReconcileClusterDeployment) syncCertificateRequests(cd *hivev1alpha1.Cl
 	// get a list of current CertificateRequests
 	currentCRs, err := r.getCurrentCertificateRequests(cd, logger)
 	if err != nil {
+		logger.Error(err, err.Error())
 		return err
 	}
 
@@ -130,8 +131,14 @@ func (r *ReconcileClusterDeployment) syncCertificateRequests(cd *hivev1alpha1.Cl
 		if cb.Generate == true {
 			domains := getDomainsForCertBundle(cb, cd)
 
-			certReq := createCertificateRequest(cb.Name, domains, cd)
-			desiredCRs = append(desiredCRs, certReq)
+			if len(domains) > 0 {
+				certReq := createCertificateRequest(cb.Name, domains, cd)
+				desiredCRs = append(desiredCRs, certReq)
+			} else {
+				err := fmt.Errorf("No domains provided for certificate bundle %v in the cluster deployment %v", cb.Name, cd.Name)
+				logger.Error(err, err.Error())
+				return err
+			}
 		}
 	}
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -137,7 +137,6 @@ func (r *ReconcileClusterDeployment) syncCertificateRequests(cd *hivev1alpha1.Cl
 			} else {
 				err := fmt.Errorf("No domains provided for certificate bundle %v in the cluster deployment %v", cb.Name, cd.Name)
 				logger.Error(err, err.Error())
-				return err
 			}
 		}
 	}


### PR DESCRIPTION
Adds a check for list of domains before creating a certificate request for the certificate bundle.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>