### PR TITLE
Add additional printer columns

### DIFF
--- a/deploy/crds/certman_v1alpha1_certificaterequest_crd.yaml
+++ b/deploy/crds/certman_v1alpha1_certificaterequest_crd.yaml
@@ -3,6 +3,19 @@ kind: CustomResourceDefinition
 metadata:
   name: certificaterequests.certman.managed.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.issuerName
+    name: IssuerName
+    type: string
+  - JSONPath: .status.notBefore
+    name: NotBefore
+    type: string
+  - JSONPath: .status.notAfter
+    name: NotAfter
+    type: string
+  - JSONPath: .spec.certificateSecret.name
+    name: Secret
+    type: string
   group: certman.managed.openshift.io
   names:
     kind: CertificateRequest

--- a/pkg/apis/certman/v1alpha1/certificaterequest_types.go
+++ b/pkg/apis/certman/v1alpha1/certificaterequest_types.go
@@ -116,11 +116,10 @@ type CertificateRequestStatus struct {
 // CertificateRequest is the Schema for the certificaterequests API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="NotBefore",type="date",JSONPath="".status.NotBefore"
-// +kubebuilder:printcolumn:name="NotAfter",type="date",JSONPath=".status.NotAfter"
-// +kubebuilder:printcolumn:name="Secret",type="string",JSONPath=".spec.CertificateSecret.Name"
-// +kubebuilder:printcolumn:name="Test Certificate",type="boolean",JSONPath=".spec.RequestTestCertificate"
-// +kubebuilder:printcolumn:name="IssuerName",type="string",JSONPath=".status.IssuerName"
+// +kubebuilder:printcolumn:name="IssuerName",type="string",JSONPath=".status.issuerName"
+// +kubebuilder:printcolumn:name="NotBefore",type="string",JSONPath=".status.notBefore"
+// +kubebuilder:printcolumn:name="NotAfter",type="string",JSONPath=".status.notAfter"
+// +kubebuilder:printcolumn:name="Secret",type="string",JSONPath=".spec.certificateSecret.name"
 type CertificateRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/controller/certificaterequest/dns.go
+++ b/pkg/controller/certificaterequest/dns.go
@@ -93,6 +93,9 @@ func (r *ReconcileCertificateRequest) AnswerDnsChallenge(acmeChallengeToken stri
 func (r *ReconcileCertificateRequest) ValidateDnsWriteAccess(cr *certmanv1alpha1.CertificateRequest) (bool, error) {
 
 	r53svc, err := r.getAwsClient(cr)
+	if err != nil {
+		return false, err
+	}
 
 	hostedZoneOutput, err := r53svc.ListHostedZones(&route53.ListHostedZonesInput{})
 	if err != nil {


### PR DESCRIPTION
This commit adds additional printer columns. Certificate validity data such as NotBefore, NotAfter and Issuer is now printed by default on `oc get` command.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>