### PR TITLE
Add certman finalizer to clusterdeployment resource

### DIFF
--- a/pkg/apis/certman/v1alpha1/certificaterequest_types.go
+++ b/pkg/apis/certman/v1alpha1/certificaterequest_types.go
@@ -149,6 +149,10 @@ type AWSPlatformSecrets struct {
 	Credentials corev1.LocalObjectReference `json:"credentials"`
 }
 
+const (
+	CertmanOperatorFinalizerLabel = "certificaterequests.certman.managed.openshift.io"
+)
+
 func init() {
 	SchemeBuilder.Register(&CertificateRequest{}, &CertificateRequestList{})
 }

--- a/pkg/controller/certificaterequest/utils.go
+++ b/pkg/controller/certificaterequest/utils.go
@@ -48,22 +48,3 @@ func GetSecret(kubeClient client.Client, secretName, namespace string) (*corev1.
 
 	return s, nil
 }
-
-func containsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
-}
-
-func removeString(slice []string, s string) (result []string) {
-	for _, item := range slice {
-		if item == s {
-			continue
-		}
-		result = append(result, item)
-	}
-	return
-}

--- a/pkg/controller/clusterdeployment/clusterdeployment_delete.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_delete.go
@@ -1,0 +1,31 @@
+package clusterdeployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	hivev1alpha1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+)
+
+func (r *ReconcileClusterDeployment) handleDelete(cd *hivev1alpha1.ClusterDeployment, logger logr.Logger) error {
+
+	// get a list of current CertificateRequests
+	currentCRs, err := r.getCurrentCertificateRequests(cd, logger)
+	if err != nil {
+		logger.Error(err, err.Error())
+		return err
+	}
+
+	// delete the  certificaterequests
+	for _, deleteCR := range currentCRs {
+		logger.Info(fmt.Sprintf("Deleting CertificateRequest resource config %q", deleteCR.Name))
+		if err := r.client.Delete(context.TODO(), &deleteCR); err != nil {
+			logger.Error(err, "error deleting CertificateRequest", "certrequest", deleteCR.Name)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/controllerutils/stringutils.go
+++ b/pkg/controller/controllerutils/stringutils.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerutils
+
+func ContainsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func RemoveString(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}


### PR DESCRIPTION
Add a finalizer to the cluster deployment resource so that it is not deleted until all the certificate requests it has created have been deleted.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>