### PR TITLE
Don't process cluster deployment until installed is set to true.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -98,6 +98,11 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
+	if !cd.Status.Installed {
+		reqLogger.Info("Cluster %v is not yet in installed state.", cd.Name)
+		return reconcile.Result{}, nil
+	}
+
 	// Do not make certificate request if the cluster is not a Red Hat managed cluster.
 	if val, ok := cd.Labels[ClusterDeploymentManagedLabel]; ok {
 		if val != "true" {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -245,6 +245,9 @@ func testClusterDeployment() *hivev1alpha1.ClusterDeployment {
 				},
 			},
 		},
+		Status: hivev1alpha1.ClusterDeploymentStatus{
+			Installed: true,
+		},
 	}
 
 	return &cd


### PR DESCRIPTION
Only process a cluster deployment resource after OpenShift v4 cluster has been succesfully installed and "Installed" is set to true.

Resolves JIRA SREP-1263

Signed-off-by: Tejas Parikh <tparikh@redhat.com>