### PR TITLE
Read operator config from configmap

### DIFF
--- a/deploy/00_namespace.yaml
+++ b/deploy/00_namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: certman-operator

--- a/deploy/crds/certman_v1alpha1_certificaterequest_crd.yaml
+++ b/deploy/crds/certman_v1alpha1_certificaterequest_crd.yaml
@@ -81,9 +81,6 @@ spec:
               description: Certificate renew before expiration duration in days.
               format: int64
               type: integer
-            requestTestCertificate:
-              description: Request Certificate from Let's Encrypt Staging Environment
-              type: boolean
           required:
           - acmeDNSDomain
           - certificateSecret

--- a/pkg/apis/certman/v1alpha1/certificaterequest_types.go
+++ b/pkg/apis/certman/v1alpha1/certificaterequest_types.go
@@ -40,16 +40,11 @@ type CertificateRequestSpec struct {
 	DnsNames []string `json:"dnsNames"`
 
 	// Let's Encrypt will use this to contact you about expiring certificates, and issues related to your account.
-	// +optional
 	Email string `json:"email"`
 
 	// Certificate renew before expiration duration in days.
 	// +optional
 	RenewBeforeDays int `json:"renewBeforeDays,omitempty"`
-
-	// Request Certificate from Let's Encrypt Staging Environment
-	// +optional
-	RequestTestCertificate bool `json:"requestTestCertificate,omitempty"`
 }
 
 type CertificateRequestCondition struct {

--- a/pkg/apis/certman/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/certman/v1alpha1/zz_generated.openapi.go
@@ -115,15 +115,8 @@ func schema_pkg_apis_certman_v1alpha1_CertificateRequestSpec(ref common.Referenc
 							Format:      "int32",
 						},
 					},
-					"requestTestCertificate": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Request Certificate from Let's Encrypt Staging Environment",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 				},
-				Required: []string{"acmeDNSDomain", "certificateSecret", "platformSecrets", "dnsNames"},
+				Required: []string{"acmeDNSDomain", "certificateSecret", "platformSecrets", "dnsNames", "email"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -126,12 +126,14 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 		if controllerutils.ContainsString(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel) {
 			reqLogger.Info("Revoking certificate and deleting secret")
 			if err := r.revokeCertificateAndDeleteSecret(cr); err != nil {
+				reqLogger.Error(err, err.Error())
 				return reconcile.Result{}, err
 			}
 
 			reqLogger.Info("Removing finalizers")
 			cr.ObjectMeta.Finalizers = controllerutils.RemoveString(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel)
 			if err := r.client.Update(context.TODO(), cr); err != nil {
+				reqLogger.Error(err, err.Error())
 				return reconcile.Result{}, err
 			}
 		}

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/eggsampler/acme"
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
+	"github.com/openshift/certman-operator/pkg/controller/controllerutils"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -39,19 +41,19 @@ func (r *ReconcileCertificateRequest) IssueCertificate(cr *certmanv1alpha1.Certi
 		log.Info("Route53 Access has been validated")
 	}
 
-	staging := cr.Spec.RequestTestCertificate
+	useLetsEncryptStagingEndpoint := controllerutils.UsetLetsEncryptStagingEnvironment(r.client)
 
-	letsEncryptClient, err := GetLetsEncryptClient(staging)
+	letsEncryptClient, err := GetLetsEncryptClient(useLetsEncryptStagingEndpoint)
 	if err != nil {
 		return err
 	}
 
-	accountUrl, err := GetLetsEncryptAccountUrl(r.client, staging, cr.Namespace)
+	accountUrl, err := GetLetsEncryptAccountUrl(r.client, useLetsEncryptStagingEndpoint, cr.Namespace)
 	if err != nil {
 		return err
 	}
 
-	privateKey, err := GetLetsEncryptAccountPrivateKey(r.client, staging, cr.Namespace)
+	privateKey, err := GetLetsEncryptAccountPrivateKey(r.client, useLetsEncryptStagingEndpoint, cr.Namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/certificaterequest/revoke_certificate.go
+++ b/pkg/controller/certificaterequest/revoke_certificate.go
@@ -23,24 +23,25 @@ import (
 	"github.com/eggsampler/acme"
 
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
+	"github.com/openshift/certman-operator/pkg/controller/controllerutils"
 )
 
 func (r *ReconcileCertificateRequest) RevokeCertificate(cr *certmanv1alpha1.CertificateRequest) error {
 
-	staging := cr.Spec.RequestTestCertificate
+	useLetsEncryptStagingEndpoint := controllerutils.UsetLetsEncryptStagingEnvironment(r.client)
 
-	letsEncryptClient, err := GetLetsEncryptClient(staging)
+	letsEncryptClient, err := GetLetsEncryptClient(useLetsEncryptStagingEndpoint)
 	if err != nil {
 		log.Error(err, "Error occurred getting Let's Encrypt client.")
 		return err
 	}
 
-	accountUrl, err := GetLetsEncryptAccountUrl(r.client, staging, cr.Namespace)
+	accountUrl, err := GetLetsEncryptAccountUrl(r.client, useLetsEncryptStagingEndpoint, cr.Namespace)
 	if err != nil {
 		return err
 	}
 
-	privateKey, err := GetLetsEncryptAccountPrivateKey(r.client, staging, cr.Namespace)
+	privateKey, err := GetLetsEncryptAccountPrivateKey(r.client, useLetsEncryptStagingEndpoint, cr.Namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -52,12 +52,14 @@ func TestReconcileClusterDeployment(t *testing.T) {
 		{
 			name: "Test no cert bundles to generate",
 			localObjects: []runtime.Object{
+				testConfigMap(),
 				testClusterDeployment(),
 			},
 		},
 		{
 			name: "Test generate control plane cert",
 			localObjects: []runtime.Object{
+				testConfigMap(),
 				testClusterDeploymentWithGenerateAPI(),
 			},
 			expectedCertificateRequests: []CertificateRequestEntry{
@@ -71,6 +73,7 @@ func TestReconcileClusterDeployment(t *testing.T) {
 			name: "Test generate cert with multi control plane",
 			localObjects: []runtime.Object{
 				testClusterDeploymentWithAdditionalControlPlaneCert(),
+				testConfigMap(),
 			},
 			expectedCertificateRequests: []CertificateRequestEntry{
 				{
@@ -86,6 +89,7 @@ func TestReconcileClusterDeployment(t *testing.T) {
 			name: "Test generate multi-control plane with ingress",
 			localObjects: []runtime.Object{
 				testClusterDeploymentWithMultiControlPlaneAndIngress(),
+				testConfigMap(),
 			},
 			expectedCertificateRequests: []CertificateRequestEntry{
 				{
@@ -107,6 +111,9 @@ func TestReconcileClusterDeployment(t *testing.T) {
 
 				cr := testCertificateRequest(cd)
 				objects = append(objects, cr)
+
+				cm := testConfigMap()
+				objects = append(objects, cm)
 
 				return objects
 			}(),
@@ -269,4 +276,21 @@ func testCertificateRequest(cd *hivev1alpha1.ClusterDeployment) *certmanv1alpha1
 	}
 
 	return &cr
+}
+
+func testConfigMap() *corev1.ConfigMap {
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "certman-operator",
+			Namespace: "certman-operator",
+		},
+		Data: map[string]string{
+			"lets_encrypt_environment":           "staging",
+			"default_notification_email_address": "email@example.com",
+		},
+	}
+
+	return &cm
+
 }

--- a/pkg/controller/controllerutils/configmap.go
+++ b/pkg/controller/controllerutils/configmap.go
@@ -58,7 +58,7 @@ func GetDefaultNotificationEmailAddress(kubeClient client.Client) (string, error
 	}
 
 	if cm.Data["default_notification_email_address"] == "" {
-		return "", fmt.Errorf("")
+		return "", fmt.Errorf("Default notification email not found in configmap.")
 	}
 
 	return cm.Data["default_notification_email_address"], nil

--- a/pkg/controller/controllerutils/configmap.go
+++ b/pkg/controller/controllerutils/configmap.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/certman-operator/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetConfig(kubeClient client.Client) (*corev1.ConfigMap, error) {
+
+	cm := &corev1.ConfigMap{}
+
+	err := kubeClient.Get(context.TODO(), types.NamespacedName{Name: "certman-operator", Namespace: config.OperatorNamespace}, cm)
+	if err != nil {
+		return nil, err
+	}
+
+	return cm, nil
+}
+
+func UsetLetsEncryptStagingEnvironment(kubeClient client.Client) bool {
+	cm, err := GetConfig(kubeClient)
+	if err != nil {
+		return true
+	}
+
+	if cm.Data["lets_encrypt_environment"] == "staging" || cm.Data["lets_encrypt_environment"] == "" {
+		return true
+	}
+
+	return false
+}
+
+func GetDefaultNotificationEmailAddress(kubeClient client.Client) (string, error) {
+	cm, err := GetConfig(kubeClient)
+	if err != nil {
+		return "", err
+	}
+
+	if cm.Data["default_notification_email_address"] == "" {
+		return "", fmt.Errorf("")
+	}
+
+	return cm.Data["default_notification_email_address"], nil
+}


### PR DESCRIPTION
Operator can be made to use the Let's Encrypt staging endpoint using configuration. Default notification email address can also be set using the config map.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>