### PR TITLE
Certman Operator should watch all namespaces

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,11 +7,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/openshift/certman-operator/pkg/apis"
-	"github.com/openshift/certman-operator/pkg/controller"
-	operatormetrics "github.com/openshift/certman-operator/pkg/metrics"
 	hivev1alpha1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
@@ -22,6 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"github.com/openshift/certman-operator/pkg/apis"
+	"github.com/openshift/certman-operator/pkg/controller"
+	operatormetrics "github.com/openshift/certman-operator/pkg/metrics"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -60,12 +60,6 @@ func main() {
 	logf.SetLogger(zap.Logger())
 
 	printVersion()
-
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
-		os.Exit(1)
-	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
+		Namespace:          "",
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,9 +21,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
As each ClusterDeployment resource is created in a separate namespace, certman operator needs to watch all namespaces.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>