### PR TITLE
Fix the Let's Encrypt account secrets namespace

### DIFF
--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -48,12 +48,12 @@ func (r *ReconcileCertificateRequest) IssueCertificate(cr *certmanv1alpha1.Certi
 		return err
 	}
 
-	accountUrl, err := GetLetsEncryptAccountUrl(r.client, useLetsEncryptStagingEndpoint, cr.Namespace)
+	accountUrl, err := GetLetsEncryptAccountUrl(r.client, useLetsEncryptStagingEndpoint)
 	if err != nil {
 		return err
 	}
 
-	privateKey, err := GetLetsEncryptAccountPrivateKey(r.client, useLetsEncryptStagingEndpoint, cr.Namespace)
+	privateKey, err := GetLetsEncryptAccountPrivateKey(r.client, useLetsEncryptStagingEndpoint)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/certificaterequest/lets_encrypt.go
+++ b/pkg/controller/certificaterequest/lets_encrypt.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/eggsampler/acme"
+	"github.com/openshift/certman-operator/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -70,7 +71,7 @@ func GetLetsEncryptAccount(kubeClient client.Client, staging bool, namespace str
 	return letsEncryptAccount, nil
 }
 
-func GetLetsEncryptAccountPrivateKey(kubeClient client.Client, staging bool, namespace string) (privateKey crypto.Signer, err error) {
+func GetLetsEncryptAccountPrivateKey(kubeClient client.Client, staging bool) (privateKey crypto.Signer, err error) {
 
 	secretName := LetsEncryptProductionAccountSecretName
 
@@ -78,7 +79,7 @@ func GetLetsEncryptAccountPrivateKey(kubeClient client.Client, staging bool, nam
 		secretName = LetsEncryptStagingAccountSecretName
 	}
 
-	secret, err := GetSecret(kubeClient, secretName, namespace)
+	secret, err := GetSecret(kubeClient, secretName, config.OperatorNamespace)
 	if err != nil {
 		return privateKey, err
 	}
@@ -98,7 +99,7 @@ func GetLetsEncryptAccountPrivateKey(kubeClient client.Client, staging bool, nam
 	return privateKey, nil
 }
 
-func GetLetsEncryptAccountUrl(kubeClient client.Client, staging bool, namespace string) (url string, err error) {
+func GetLetsEncryptAccountUrl(kubeClient client.Client, staging bool) (url string, err error) {
 
 	secretName := LetsEncryptProductionAccountSecretName
 
@@ -106,7 +107,7 @@ func GetLetsEncryptAccountUrl(kubeClient client.Client, staging bool, namespace 
 		secretName = LetsEncryptStagingAccountSecretName
 	}
 
-	secret, err := GetSecret(kubeClient, secretName, namespace)
+	secret, err := GetSecret(kubeClient, secretName, config.OperatorNamespace)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/certificaterequest/revoke_certificate.go
+++ b/pkg/controller/certificaterequest/revoke_certificate.go
@@ -36,12 +36,12 @@ func (r *ReconcileCertificateRequest) RevokeCertificate(cr *certmanv1alpha1.Cert
 		return err
 	}
 
-	accountUrl, err := GetLetsEncryptAccountUrl(r.client, useLetsEncryptStagingEndpoint, cr.Namespace)
+	accountUrl, err := GetLetsEncryptAccountUrl(r.client, useLetsEncryptStagingEndpoint)
 	if err != nil {
 		return err
 	}
 
-	privateKey, err := GetLetsEncryptAccountPrivateKey(r.client, useLetsEncryptStagingEndpoint, cr.Namespace)
+	privateKey, err := GetLetsEncryptAccountPrivateKey(r.client, useLetsEncryptStagingEndpoint)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Let's Encrypt account namepsace is same as operator namespace and not the clusterdeployment namespace. This commit fixes the namespace where we look up LE secret.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>