### PR TITLE
Fix a log message formatting issue

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -99,7 +99,7 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 	}
 
 	if !cd.Status.Installed {
-		reqLogger.Info("Cluster %v is not yet in installed state.", cd.Name)
+		reqLogger.Info(fmt.Sprintf("Cluster %v is not yet in installed state.", cd.Name))
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
A log message was written incorrectly which is causing an error creating noise in app logs.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>