### PR TITLE
Store certificates in secret of type SecretTypeTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,35 @@
 # Let's Encrypt Certificate Management Operator
 
+## Project Status
+
+**Project status: Alpha**
+
+Not all planned features are completed. As this project is pre-1.0, we do not currently offer strong guarantees around our API stability. The API, spec, status and other user facing objects may change in a non-backward compatible way.
+
+## About
+
+The Certman Operator is used to automate the management and issuance of TLS certificates from [Let's Encrypt](https://letsencrypt.org/) for [OpenShift Dedicated](https://www.openshift.com/products/dedicated/) clusters provisioned via https://cloud.redhat.com/.
+
+It will ensure certificates are valid and up to date, and attempt to renew certificates before expiry.
+
+The Certman Operator watches [ClusterDeployment](https://github.com/openshift/hive/blob/master/config/crds/hive_v1alpha1_clusterdeployment.yaml) resource which is managd by [Hive](https://github.com/openshift/hive). Hive is API driven OpenShift cluster provisioning and management. Once an OpenShift Dedicated cluster has been successfully installed by Hive, Certman Operator will create a `CertificateRequest` resource. Based on details in the `CertificateRequest` resource, Certman Operator will order a new certificate from Let's Encrypt.
+
+When you delete a OpenShift Dedicated cluster (i.e. when a ClusterDeployment is deleted), Certman Operator will revoke all valid certificates issued for the cluster.
+
+### Limitations
+
+* Certman Operator has dependency on [Hive](https://github.com/openshift/hive) custom resources. It is therefore not suitable for certificate management on a cluster. We recommend using either [openshift-acme](https://github.com/tnozicka/openshift-acme) or [cert-manager](https://github.com/jetstack/cert-manager). Certman Operator is ideal for use cases when large number of OpenShift clusters have to be managed centrally.
+* Certman Operator currently only supports [DNS Challenge](https://tools.ietf.org/html/rfc8555#section-8.4) through AWS Route53 for. [HTTP Challenge](https://tools.ietf.org/html/rfc8555#section-8.3) is not supported.
+* Certman Operator does not support creation of Let's Encrypt account at this time. You must already have Let's Encrypt account and keys that you can provide to the Certman Operator.
+* Certman Operator does NOT configure the TLS certificates in an OpenShift cluster. This is managed by [Hive](https://github.com/openshift/hive) using [SyncSet](https://github.com/openshift/hive/blob/master/docs/syncset.md).
+
+## CustomResourceDefinitions
+
+The Certman Operator acts on the following custom resource definitions (CRDs):
+
+* **`CertificateRequest`**, which provides the details needed to request a certificate from Let's Encrypt.
+
+* **`ClusterDeployment`**, which defines a desired OpenShift managed cluster. The Operator ensures at all times that the OpenShift managed cluster has valid certificates for control plane and pre-defined external routes.
+
 
 

--- a/pkg/controller/certificaterequest/certificate.go
+++ b/pkg/controller/certificaterequest/certificate.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -32,7 +33,7 @@ func GetCertificate(kubeClient client.Client, cr *certmanv1alpha1.CertificateReq
 		return nil, err
 	}
 
-	data := crtSecret.Data[TlsCertificateSecretKey]
+	data := crtSecret.Data[corev1.TLSCertKey]
 	if data == nil {
 		return nil, fmt.Errorf("certificate data was not found in secret %v", cr.Spec.CertificateSecret.Name)
 	}

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -212,13 +212,13 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 		log.Error(err, err.Error())
 	}
 
-	reqLogger.Info("Skip reconcile as valid certificates exist", "Secret.Namespace", found.Namespace, "Secret.Name", found.Name)
+	// reqLogger.Info("Skip reconcile as valid certificates exist", "Secret.Namespace", found.Namespace, "Secret.Name", found.Name)
 	return reconcile.Result{}, nil
 }
 
 func newSecret(cr *certmanv1alpha1.CertificateRequest) *corev1.Secret {
 	return &corev1.Secret{
-		Type: corev1.SecretTypeOpaque,
+		Type: corev1.SecretTypeTLS,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Spec.CertificateSecret.Name,
 			Namespace: cr.Namespace,

--- a/pkg/controller/certificaterequest/constants.go
+++ b/pkg/controller/certificaterequest/constants.go
@@ -24,10 +24,7 @@ const (
 	WaitTimePeriodDnsPropogationCheck      = 60
 	LetsEncryptAccountPrivateKey           = "private-key"
 	LetsEncryptAccountUrl                  = "account-url"
-	TlsCertificateSecretKey                = "crt"
 	AcmeChallengeSubDomain                 = "_acme-challenge"
-	OpenShiftDotCom                        = "openshift.com"
-	OpenShiftAppsDotCom                    = "openshiftapps.com"
 	RenewCertificateBeforeDays             = 45 // This helps us avoid getting email notifications from Let's Encrypt.
 	ResourceRecordTTL                      = 60
 	RSAKeyBitSize                          = 2048

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -171,13 +171,12 @@ func (r *ReconcileCertificateRequest) IssueCertificate(cr *certmanv1alpha1.Certi
 
 	certificateSecret.Labels = map[string]string{
 		"certificate_request": cr.Name,
-		"acme_dns_domain":     cr.Spec.ACMEDNSDomain,
 	}
 
 	certificateSecret.Data = map[string][]byte{
-		TlsCertificateSecretKey: []byte(pemData[0]),
-		"key":                   key,
-		"letsencrypt.ca.crt":    []byte(pemData[1]),
+		corev1.TLSCertKey:       []byte(pemData[0] + pemData[1]), // create fullchain
+		corev1.TLSPrivateKeyKey: key,
+		// "letsencrypt.ca.crt":    []byte(pemData[1]),
 	}
 
 	return nil

--- a/pkg/controller/certificaterequest/lets_encrypt.go
+++ b/pkg/controller/certificaterequest/lets_encrypt.go
@@ -126,7 +126,5 @@ func GetCertExpiryNotificationList(email string) []string {
 		contacts = append(contacts, "mailto:"+email)
 	}
 
-	//todo add default email
-
 	return contacts
 }

--- a/pkg/controller/certificaterequest/renew_certificate.go
+++ b/pkg/controller/certificaterequest/renew_certificate.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (r *ReconcileCertificateRequest) ShouldRenewOrReIssue(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) (bool, error) {
@@ -38,7 +38,7 @@ func (r *ReconcileCertificateRequest) ShouldRenewOrReIssue(reqLogger logr.Logger
 		return false, err
 	}
 
-	data := crtSecret.Data[TlsCertificateSecretKey]
+	data := crtSecret.Data[corev1.TLSCertKey]
 	if data == nil {
 		log.Info(fmt.Sprintf("certificate data was not found in secret %v", cr.Spec.CertificateSecret.Name))
 		return true, nil


### PR DESCRIPTION
This commit includes following:
* Change from Secret's type Opaque to SecretTypeTLS
* Update README.md
* tls.crt now contains full certificate chain.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>