### PR TITLE
Add core maintainers to reviewer and approver in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+- tparikh
 - aweiteka
 - jewzaam
 - mwoodson
@@ -6,3 +7,5 @@ reviewers:
 - aweiteka
 - jewzaam
 - mwoodson
+- fahlmant
+- tparikh


### PR DESCRIPTION
Reverts changes made to OWNERS file.
Add tparikh as approver and reviewer.
Add fahlmant as reviewer.
Team leads are already part of reviewer and approver.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>