### PR TITLE
Append "*." prefix to all ingress domain names

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -293,8 +293,15 @@ func getDomainsForCertBundle(cb hivev1alpha1.CertificateBundleSpec, cd *hivev1al
 	// and lastly the ingress list
 	for _, ingress := range cd.Spec.Ingress {
 		if ingress.ServingCertificate == cb.Name {
-			dLogger.Info("Ingress domain added to certificate request: " + ingress.Domain)
-			domains = append(domains, ingress.Domain)
+			ingressDomain := ingress.Domain
+
+			// always request wildcard certificates for the ingress domain
+			if !strings.HasPrefix(ingressDomain, "*.") {
+				ingressDomain = fmt.Sprintf("*.%s", ingress.Domain)
+			}
+
+			dLogger.Info("Ingress domain added to certificate request: " + ingressDomain)
+			domains = append(domains, ingressDomain)
 		}
 	}
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -32,7 +32,7 @@ const (
 	testCertBundleName           = "testbundle"
 	testAWSCredentialsSecret     = "aws-credentials"
 	testExtraControlPlaneDNSName = "anotherapi.testing.example.com"
-	testIngressDefaultDomain     = "apps.testing.example.com"
+	testIngressDefaultDomain     = "*.apps.testing.example.com"
 )
 
 type CertificateRequestEntry struct {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -32,7 +32,7 @@ const (
 	testCertBundleName           = "testbundle"
 	testAWSCredentialsSecret     = "aws-credentials"
 	testExtraControlPlaneDNSName = "anotherapi.testing.example.com"
-	testIngressDefaultDomain     = "*.apps.testing.example.com"
+	testIngressDefaultDomain     = "apps.testing.example.com"
 )
 
 type CertificateRequestEntry struct {
@@ -97,7 +97,7 @@ func TestReconcileClusterDeployment(t *testing.T) {
 					dnsNames: []string{
 						fmt.Sprintf("api.%s.%s", testClusterName, testBaseDomain),
 						testExtraControlPlaneDNSName,
-						testIngressDefaultDomain,
+						"*." + testIngressDefaultDomain,
 					},
 				},
 			},


### PR DESCRIPTION
Domain names listed for all ingress routes in ClusterDeployment spec need wildcard certificates. However, the domain names do not have "*." prefix to them. When a CertificaeRequest is created for a cluster, we must add the prefix so wildcard certificates are requested for that domain.

Ingress domain `foo.bar.com` becomes `*.foo.bar.com` for the certificate request.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>