### PR TITLE
Improve logging

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -106,7 +106,6 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			reqLogger.Error(err, err.Error())
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -141,6 +140,7 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 				return reconcile.Result{}, err
 			}
 		}
+		reqLogger.Info("certificaterequest has been deleted")
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -118,7 +118,7 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 	if cr.DeletionTimestamp.IsZero() {
 		// add finalizer
 		if !controllerutils.ContainsString(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel) {
-			reqLogger.Info("Adding finalizer to the certificate request.")
+			reqLogger.Info("adding finalizer to the certificate request")
 			cr.ObjectMeta.Finalizers = append(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel)
 			if err := r.client.Update(context.TODO(), cr); err != nil {
 				reqLogger.Error(err, err.Error())
@@ -128,13 +128,13 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 	} else {
 		// The object is being deleted
 		if controllerutils.ContainsString(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel) {
-			reqLogger.Info("Revoking certificate and deleting secret")
+			reqLogger.Info("revoking certificate and deleting secret")
 			if err := r.revokeCertificateAndDeleteSecret(reqLogger, cr); err != nil {
 				reqLogger.Error(err, err.Error())
 				return reconcile.Result{}, err
 			}
 
-			reqLogger.Info("Removing finalizers")
+			reqLogger.Info("removing finalizers")
 			cr.ObjectMeta.Finalizers = controllerutils.RemoveString(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel)
 			if err := r.client.Update(context.TODO(), cr); err != nil {
 				reqLogger.Error(err, err.Error())
@@ -159,7 +159,7 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 	// Issue New Certifcates
 	if err != nil && errors.IsNotFound(err) {
 
-		reqLogger.Info("Secret was not found. Requesting new certificates.")
+		reqLogger.Info("requesting new certificates as secret was not found")
 
 		err := r.IssueCertificate(reqLogger, cr, certificateSecret)
 		if err != nil {
@@ -206,8 +206,6 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	reqLogger.Info("ShouldRenew", "ShouldRenewOrReIssue", shouldRenewOrReIssue)
-
 	if shouldRenewOrReIssue {
 		err := r.IssueCertificate(reqLogger, cr, found)
 		if err != nil {
@@ -225,7 +223,6 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 		}
 
 		reqLogger.Info("certificate has been renewed/re-issued.")
-		r.recorder.Event(cr, "Normal", "Updated", fmt.Sprintf("Certificates renewed and stored in secret  %s/%s", certificateSecret.Namespace, certificateSecret.Name))
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/certificaterequest/cloudflare.go
+++ b/pkg/controller/certificaterequest/cloudflare.go
@@ -89,7 +89,7 @@ func ValidateResourceRecordUpdatesUsingCloudflareDns(reqLogger logr.Logger, name
 	var request, err = http.NewRequest("GET", requestUrl, nil)
 
 	if err != nil {
-		reqLogger.Error(err, "Error occurred creating new Cloudflare DnsOverHttps request")
+		reqLogger.Error(err, "error occurred creating new cloudflare dns-over-https request")
 		return false, err
 	}
 
@@ -101,7 +101,7 @@ func ValidateResourceRecordUpdatesUsingCloudflareDns(reqLogger logr.Logger, name
 
 	response, err := netClient.Do(request)
 	if err != nil {
-		reqLogger.Error(err, "Error occurred executing request")
+		reqLogger.Error(err, "error occurred executing request")
 		return false, err
 	}
 	defer response.Body.Close()
@@ -112,22 +112,22 @@ func ValidateResourceRecordUpdatesUsingCloudflareDns(reqLogger logr.Logger, name
 		return false, err
 	}
 
-	reqLogger.Info("Response from Cloudflare: " + string(responseBody))
+	reqLogger.Info("response from Cloudflare: " + string(responseBody))
 
 	var cloudflareResponse CloudflareResponse
 
 	err = json.Unmarshal(responseBody, &cloudflareResponse)
 	if err != nil {
-		reqLogger.Error(err, "There was problem parsing the JSON response from Cloudflare.")
+		reqLogger.Error(err, "there was problem parsing the json response from cloudflare.")
 		return false, err
 	}
 
 	if len(cloudflareResponse.Answers) == 0 {
-		reqLogger.Error(err, "No answers received from Cloudflare")
-		return false, errors.New("No answers received from Cloudflare")
+		reqLogger.Error(err, "no answers received from cloudflare")
+		return false, errors.New("no answers received from cloudflare")
 	}
 
-	if (len(cloudflareResponse.Answers) > 0) && (strings.EqualFold(cloudflareResponse.Answers[0].Name, (name + "."))) {
+	if (len(cloudflareResponse.Answers) > 0) && (strings.EqualFold(cloudflareResponse.Answers[0].Name, name+".")) {
 		cfData := cloudflareResponse.Answers[0].Data
 		// trim quotes from value
 		if len(cfData) >= 2 {
@@ -135,8 +135,8 @@ func ValidateResourceRecordUpdatesUsingCloudflareDns(reqLogger logr.Logger, name
 				cfData = cfData[1 : len(cfData)-1]
 			}
 		}
-		return (cfData == value), nil
+		return cfData == value, nil
 	}
 
-	return false, errors.New("Could not validate DNS propogation for " + name)
+	return false, errors.New("could not validate DNS propogation for " + name)
 }

--- a/pkg/controller/certificaterequest/cloudflare.go
+++ b/pkg/controller/certificaterequest/cloudflare.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 )
 
@@ -50,25 +51,25 @@ type CloudflareResponse struct {
 	Answers   []CloudflareAnswer   `json:"Answer"`
 }
 
-func VerifyDnsResourceRecordUpdate(fqdn string, txtValue string) bool {
-	return verifyDnsResourceRecordUpdate(fqdn, txtValue, 1)
+func VerifyDnsResourceRecordUpdate(reqLogger logr.Logger, fqdn string, txtValue string) bool {
+	return verifyDnsResourceRecordUpdate(reqLogger, fqdn, txtValue, 1)
 }
 
-func verifyDnsResourceRecordUpdate(fqdn string, txtValue string, attempt int) bool {
+func verifyDnsResourceRecordUpdate(reqLogger logr.Logger, fqdn string, txtValue string, attempt int) bool {
 
 	if attempt > MaxAttemptsForDnsPropogationCheck {
-		errMsg := fmt.Sprintf("Unable to verify that resource record %v has been updated to value %v after %v attempts.", fqdn, txtValue, MaxAttemptsForDnsPropogationCheck)
-		log.Error(errors.New(errMsg), errMsg)
+		errMsg := fmt.Sprintf("unable to verify that resource record %v has been updated to value %v after %v attempts.", fqdn, txtValue, MaxAttemptsForDnsPropogationCheck)
+		reqLogger.Error(errors.New(errMsg), errMsg)
 		return false
 	}
 
-	log.Info(fmt.Sprintf("Will query DNS in %v seconds. Attempt %v to verify resource record %v has been updated with value %v", WaitTimePeriodDnsPropogationCheck, attempt, fqdn, txtValue))
+	reqLogger.Info(fmt.Sprintf("will query DNS in %v seconds. Attempt %v to verify resource record %v has been updated with value %v", WaitTimePeriodDnsPropogationCheck, attempt, fqdn, txtValue))
 
 	time.Sleep(time.Duration(WaitTimePeriodDnsPropogationCheck) * time.Second)
 
-	dnsChangesPorpogated, err := ValidateResourceRecordUpdatesUsingCloudflareDns(fqdn, txtValue)
+	dnsChangesPorpogated, err := ValidateResourceRecordUpdatesUsingCloudflareDns(reqLogger, fqdn, txtValue)
 	if err != nil {
-		log.Error(err, "Could not validate DNS propogation.")
+		reqLogger.Error(err, "could not validate DNS propagation.")
 		return false
 	}
 
@@ -76,19 +77,19 @@ func verifyDnsResourceRecordUpdate(fqdn string, txtValue string, attempt int) bo
 		return dnsChangesPorpogated
 	}
 
-	return verifyDnsResourceRecordUpdate(fqdn, txtValue, attempt+1)
+	return verifyDnsResourceRecordUpdate(reqLogger, fqdn, txtValue, attempt+1)
 }
 
-func ValidateResourceRecordUpdatesUsingCloudflareDns(name string, value string) (bool, error) {
+func ValidateResourceRecordUpdatesUsingCloudflareDns(reqLogger logr.Logger, name string, value string) (bool, error) {
 
 	requestUrl := CloudflareDnsOverHttpsEndpoint + "?name=" + name + "&type=TXT"
 
-	log.Info(fmt.Sprintf("Cloudflare DnsOverHttps Request URL: %v", requestUrl))
+	reqLogger.Info(fmt.Sprintf("cloudflare dns-over-https Request URL: %v", requestUrl))
 
 	var request, err = http.NewRequest("GET", requestUrl, nil)
 
 	if err != nil {
-		log.Error(err, "Error occurred creating new Cloudflare DnsOverHttps request")
+		reqLogger.Error(err, "Error occurred creating new Cloudflare DnsOverHttps request")
 		return false, err
 	}
 
@@ -100,29 +101,29 @@ func ValidateResourceRecordUpdatesUsingCloudflareDns(name string, value string) 
 
 	response, err := netClient.Do(request)
 	if err != nil {
-		log.Error(err, "Error occurred executing request")
+		reqLogger.Error(err, "Error occurred executing request")
 		return false, err
 	}
 	defer response.Body.Close()
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		log.Error(err, "")
+		reqLogger.Error(err, "")
 		return false, err
 	}
 
-	log.Info("Response from Cloudflare: " + string(responseBody))
+	reqLogger.Info("Response from Cloudflare: " + string(responseBody))
 
 	var cloudflareResponse CloudflareResponse
 
 	err = json.Unmarshal(responseBody, &cloudflareResponse)
 	if err != nil {
-		log.Error(err, "There was problem parsing the JSON response from Cloudflare.")
+		reqLogger.Error(err, "There was problem parsing the JSON response from Cloudflare.")
 		return false, err
 	}
 
 	if len(cloudflareResponse.Answers) == 0 {
-		log.Error(err, "No answers received from Cloudflare")
+		reqLogger.Error(err, "No answers received from Cloudflare")
 		return false, errors.New("No answers received from Cloudflare")
 	}
 

--- a/pkg/controller/certificaterequest/dns.go
+++ b/pkg/controller/certificaterequest/dns.go
@@ -32,7 +32,7 @@ func (r *ReconcileCertificateRequest) AnswerDnsChallenge(reqLogger logr.Logger, 
 
 	fqdn = AcmeChallengeSubDomain + "." + domain
 
-	reqLogger.Info(fmt.Sprintf("fqdn acme challenge domain is %q", fqdn))
+	reqLogger.Info(fmt.Sprintf("fqdn acme challenge domain is %v", fqdn))
 
 	r53svc, err := r.getAwsClient(cr)
 	if err != nil {
@@ -198,7 +198,7 @@ func (r *ReconcileCertificateRequest) DeleteAcmeChallengeResourceRecords(reqLogg
 					fqdn := AcmeChallengeSubDomain + domain
 					fqdnWithDot := fqdn + "."
 
-					log.Info("Deleting RR: " + fqdn)
+					reqLogger.Info(fmt.Sprintf("deleting resource record %v", fqdn))
 
 					resp, err := r53svc.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
 						HostedZoneId:    aws.String(*hostedzone.Id), // Required

--- a/pkg/controller/certificaterequest/dns.go
+++ b/pkg/controller/certificaterequest/dns.go
@@ -18,25 +18,31 @@ package certificaterequest
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/go-logr/logr"
 
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
 )
 
-func (r *ReconcileCertificateRequest) AnswerDnsChallenge(acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (fqdn string, err error) {
+func (r *ReconcileCertificateRequest) AnswerDnsChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (fqdn string, err error) {
 
 	fqdn = AcmeChallengeSubDomain + "." + domain
 
+	reqLogger.Info(fmt.Sprintf("fqdn acme challenge domain is %q", fqdn))
+
 	r53svc, err := r.getAwsClient(cr)
 	if err != nil {
+		reqLogger.Error(err, err.Error())
 		return fqdn, err
 	}
 
 	hostedZoneOutput, err := r53svc.ListHostedZones(&route53.ListHostedZonesInput{})
 	if err != nil {
+		reqLogger.Error(err, err.Error())
 		return fqdn, err
 	}
 
@@ -50,6 +56,7 @@ func (r *ReconcileCertificateRequest) AnswerDnsChallenge(acmeChallengeToken stri
 		if strings.EqualFold(baseDomain, *hostedzone.Name) {
 			zone, err := r53svc.GetHostedZone(&route53.GetHostedZoneInput{Id: hostedzone.Id})
 			if err != nil {
+				reqLogger.Error(err, err.Error())
 				return fqdn, err
 			}
 
@@ -76,9 +83,11 @@ func (r *ReconcileCertificateRequest) AnswerDnsChallenge(acmeChallengeToken stri
 					HostedZoneId: hostedzone.Id,
 				}
 
+				reqLogger.Info(fmt.Sprintf("updating hosted zone %v", hostedzone.Name))
+
 				result, err := r53svc.ChangeResourceRecordSets(input)
 				if err != nil {
-					log.Error(err, result.GoString(), "FQDN", fqdn)
+					reqLogger.Error(err, result.GoString(), "fqdn", fqdn)
 					return fqdn, err
 				}
 
@@ -87,10 +96,10 @@ func (r *ReconcileCertificateRequest) AnswerDnsChallenge(acmeChallengeToken stri
 		}
 	}
 
-	return fqdn, errors.New("Unknown error prevented from answering DNS challenge.")
+	return fqdn, errors.New("unknown error prevented from answering DNS challenge")
 }
 
-func (r *ReconcileCertificateRequest) ValidateDnsWriteAccess(cr *certmanv1alpha1.CertificateRequest) (bool, error) {
+func (r *ReconcileCertificateRequest) ValidateDnsWriteAccess(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) (bool, error) {
 
 	r53svc, err := r.getAwsClient(cr)
 	if err != nil {
@@ -140,6 +149,8 @@ func (r *ReconcileCertificateRequest) ValidateDnsWriteAccess(cr *certmanv1alpha1
 					HostedZoneId: hostedzone.Id,
 				}
 
+				reqLogger.Info(fmt.Sprintf("updating hosted zone %v", hostedzone.Name))
+
 				_, err := r53svc.ChangeResourceRecordSets(input)
 				if err != nil {
 					return false, err
@@ -153,7 +164,7 @@ func (r *ReconcileCertificateRequest) ValidateDnsWriteAccess(cr *certmanv1alpha1
 	return false, nil
 }
 
-func (r *ReconcileCertificateRequest) DeleteAcmeChallengeResourceRecords(cr *certmanv1alpha1.CertificateRequest) error {
+func (r *ReconcileCertificateRequest) DeleteAcmeChallengeResourceRecords(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) error {
 
 	r53svc, err := r.getAwsClient(cr)
 	if err != nil {
@@ -228,7 +239,13 @@ func (r *ReconcileCertificateRequest) DeleteAcmeChallengeResourceRecords(cr *cer
 								HostedZoneId: hostedzone.Id,
 							}
 
-							r53svc.ChangeResourceRecordSets(input)
+							reqLogger.Info(fmt.Sprintf("updating hosted zone %v", hostedzone.Name))
+
+							result, err := r53svc.ChangeResourceRecordSets(input)
+							if err != nil {
+								reqLogger.Error(err, result.GoString())
+								return nil
+							}
 						}
 					}
 				}

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -77,7 +77,7 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 	var ids []acme.Identifier
 
 	for _, domain := range cr.Spec.DnsNames {
-		reqLogger.Info(fmt.Sprintf("%q domain will be added to certificate request", domain))
+		reqLogger.Info(fmt.Sprintf("%v domain will be added to certificate request", domain))
 		certDomains = append(certDomains, domain)
 		ids = append(ids, acme.Identifier{Type: "dns", Value: domain})
 	}
@@ -96,6 +96,8 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 			reqLogger.Error(err, "could not fetch authorizations")
 			return err
 		}
+
+		reqLogger.Info("authorization url", "authorization.URL", authorization.URL)
 
 		domain := authorization.Identifier.Value
 

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -46,7 +46,7 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 	useLetsEncryptStagingEndpoint := controllerutils.UsetLetsEncryptStagingEnvironment(r.client)
 
 	if useLetsEncryptStagingEndpoint {
-		reqLogger.Info("Operator is configured to use Let's Encrypt staging environment.")
+		reqLogger.Info("operator is configured to use Let's Encrypt staging environment.")
 	}
 
 	letsEncryptClient, err := GetLetsEncryptClient(useLetsEncryptStagingEndpoint)
@@ -87,13 +87,13 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 		return err
 	}
 
-	reqLogger.Info("Created a new order with Let's Encrypt.", "letsEncryptOrder.URL", letsEncryptOrder.URL)
+	reqLogger.Info("created a new order with Let's Encrypt.", "letsEncryptOrder.URL", letsEncryptOrder.URL)
 
 	for _, authUrl := range letsEncryptOrder.Authorizations {
 
 		authorization, err := letsEncryptClient.FetchAuthorization(letsEncryptAccount, authUrl)
 		if err != nil {
-			reqLogger.Error(err, "There was problem fetching authorizations.")
+			reqLogger.Error(err, "could not fetch authorizations")
 			return err
 		}
 
@@ -101,7 +101,7 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 
 		challenge, ok := authorization.ChallengeMap[acme.ChallengeTypeDNS01]
 		if !ok {
-			return fmt.Errorf("Cloud not find DNS Challenge Authorization.")
+			return fmt.Errorf("cloud not find DNS challenge authorization")
 		}
 
 		encodeDNS01KeyAuthorization := acme.EncodeDNS01KeyAuthorization(challenge.KeyAuthorization)
@@ -113,18 +113,18 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 
 		dnsChangesVerified := VerifyDnsResourceRecordUpdate(reqLogger, fqdn, encodeDNS01KeyAuthorization)
 		if !dnsChangesVerified {
-			return fmt.Errorf("Could not verify DNS changes. Cannot complete Let's Encrypt challenege.")
+			return fmt.Errorf("cannot complete Let's Encrypt challenege as DNS changes could not be verified")
 		}
 
-		reqLogger.Info(fmt.Sprintf("Updating challenge for authorization %v: %v", authorization.Identifier.Value, challenge.URL))
+		reqLogger.Info(fmt.Sprintf("updating challenge for authorization %v: %v", authorization.Identifier.Value, challenge.URL))
 
 		challenge, err = letsEncryptClient.UpdateChallenge(letsEncryptAccount, challenge)
 		if err != nil {
-			reqLogger.Error(err, fmt.Sprintf("Error updating authorization %s challenge: %v", authorization.Identifier.Value, err))
+			reqLogger.Error(err, fmt.Sprintf("error updating authorization %s challenge: %v", authorization.Identifier.Value, err))
 			return err
 		}
 
-		reqLogger.Info("Challenge successfully completed.")
+		reqLogger.Info("challenge successfully completed")
 	}
 
 	reqLogger.Info("generating new key")

--- a/pkg/controller/certificaterequest/renew_certificate.go
+++ b/pkg/controller/certificaterequest/renew_certificate.go
@@ -61,9 +61,9 @@ func (r *ReconcileCertificateRequest) ShouldRenewOrReIssue(reqLogger logr.Logger
 		shouldRenew := daysCertificateValidFor <= renewBeforeDays
 
 		if shouldRenew {
-			reqLogger.Info(fmt.Sprintf("certificate is valid notBefore %q and notAfter %q. certificate is valid for %d days and will be renewed.", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))
+			reqLogger.Info(fmt.Sprintf("certificate is valid notBefore %q and notAfter %q and is valid for %d days and will be renewed", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))
 		} else {
-			reqLogger.Info(fmt.Sprintf("certificate is valid notBefore %q and notAfter %q. certificate is valid for %d days and will NOT be renewed.", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))
+			reqLogger.Info(fmt.Sprintf("certificate is valid notBefore %q and notAfter %q and is valid for %d days and will NOT be renewed", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))
 		}
 
 		return shouldRenew, nil

--- a/pkg/controller/certificaterequest/renew_certificate.go
+++ b/pkg/controller/certificaterequest/renew_certificate.go
@@ -33,7 +33,7 @@ func (r *ReconcileCertificateRequest) ShouldRenewOrReIssue(reqLogger logr.Logger
 		renewBeforeDays = RenewCertificateBeforeDays
 	}
 
-	reqLogger.Info(fmt.Sprintf("certificate needs to be renewed %d days before expiry", renewBeforeDays))
+	reqLogger.Info(fmt.Sprintf("certificate is configured to be renewed %d days before expiry", renewBeforeDays))
 
 	crtSecret, err := GetSecret(r.client, cr.Spec.CertificateSecret.Name, cr.Namespace)
 	if err != nil {
@@ -61,9 +61,9 @@ func (r *ReconcileCertificateRequest) ShouldRenewOrReIssue(reqLogger logr.Logger
 		shouldRenew := daysCertificateValidFor <= renewBeforeDays
 
 		if shouldRenew {
-			reqLogger.Info(fmt.Sprintf("certificate is valid notBefore %q and notAfter %q and is valid for %d days and will be renewed", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))
+			reqLogger.Info(fmt.Sprintf("certificate is valid from (notBefore) %v and until (notAfter) %v and is valid for %d days and will be renewed", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))
 		} else {
-			reqLogger.Info(fmt.Sprintf("certificate is valid notBefore %q and notAfter %q and is valid for %d days and will NOT be renewed", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))
+			reqLogger.Info(fmt.Sprintf("certificate is valid from (notBefore) %v and until (notAfter) %v and is valid for %d days and will NOT be renewed", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))
 		}
 
 		return shouldRenew, nil

--- a/pkg/controller/certificaterequest/revoke_certificate.go
+++ b/pkg/controller/certificaterequest/revoke_certificate.go
@@ -32,12 +32,12 @@ func (r *ReconcileCertificateRequest) RevokeCertificate(reqLogger logr.Logger, c
 	useLetsEncryptStagingEndpoint := controllerutils.UsetLetsEncryptStagingEnvironment(r.client)
 
 	if useLetsEncryptStagingEndpoint {
-		reqLogger.Info("Operator is configured to use Let's Encrypt staging environment.")
+		reqLogger.Info("operator is configured to use Let's Encrypt staging environment")
 	}
 
 	letsEncryptClient, err := GetLetsEncryptClient(useLetsEncryptStagingEndpoint)
 	if err != nil {
-		reqLogger.Error(err, "Error occurred getting Let's Encrypt client.")
+		reqLogger.Error(err, "error occurred getting Let's Encrypt client")
 		return err
 	}
 
@@ -55,7 +55,7 @@ func (r *ReconcileCertificateRequest) RevokeCertificate(reqLogger logr.Logger, c
 
 	certificate, err := GetCertificate(r.client, cr)
 	if err != nil {
-		reqLogger.Error(err, "Error occurred loading current certificate.")
+		reqLogger.Error(err, "error occurred loading current certificate")
 		return err
 	}
 
@@ -65,14 +65,14 @@ func (r *ReconcileCertificateRequest) RevokeCertificate(reqLogger logr.Logger, c
 				return err
 			}
 		}
-		reqLogger.Info("certificate have been successfully revoked.")
+		reqLogger.Info("certificate have been successfully revoked")
 	} else {
 		return fmt.Errorf("certificate was not issued by Let's Encrypt and cannot be revoked by the operator")
 	}
 
 	err = r.DeleteAcmeChallengeResourceRecords(reqLogger, cr)
 	if err != nil {
-		reqLogger.Error(err, "Error occurred deleting acme challenge resource records from Route53")
+		reqLogger.Error(err, "error occurred deleting acme challenge resource records from Route53")
 	}
 
 	return nil

--- a/pkg/controller/certificaterequest/revoke_certificate.go
+++ b/pkg/controller/certificaterequest/revoke_certificate.go
@@ -21,18 +21,23 @@ import (
 	"strings"
 
 	"github.com/eggsampler/acme"
+	"github.com/go-logr/logr"
 
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
 	"github.com/openshift/certman-operator/pkg/controller/controllerutils"
 )
 
-func (r *ReconcileCertificateRequest) RevokeCertificate(cr *certmanv1alpha1.CertificateRequest) error {
+func (r *ReconcileCertificateRequest) RevokeCertificate(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) error {
 
 	useLetsEncryptStagingEndpoint := controllerutils.UsetLetsEncryptStagingEnvironment(r.client)
 
+	if useLetsEncryptStagingEndpoint {
+		reqLogger.Info("Operator is configured to use Let's Encrypt staging environment.")
+	}
+
 	letsEncryptClient, err := GetLetsEncryptClient(useLetsEncryptStagingEndpoint)
 	if err != nil {
-		log.Error(err, "Error occurred getting Let's Encrypt client.")
+		reqLogger.Error(err, "Error occurred getting Let's Encrypt client.")
 		return err
 	}
 
@@ -50,7 +55,7 @@ func (r *ReconcileCertificateRequest) RevokeCertificate(cr *certmanv1alpha1.Cert
 
 	certificate, err := GetCertificate(r.client, cr)
 	if err != nil {
-		log.Error(err, "Error occurred loading current certificate.")
+		reqLogger.Error(err, "Error occurred loading current certificate.")
 		return err
 	}
 
@@ -60,15 +65,14 @@ func (r *ReconcileCertificateRequest) RevokeCertificate(cr *certmanv1alpha1.Cert
 				return err
 			}
 		}
-		log.Info("Certificates were successfully revoked.")
+		reqLogger.Info("certificate have been successfully revoked.")
 	} else {
-		return fmt.Errorf("Certificate was not issued by Let's Encrypt. Certman operator cannot revoke this certificate.")
+		return fmt.Errorf("certificate was not issued by Let's Encrypt and cannot be revoked by the operator")
 	}
 
-	err = r.DeleteAcmeChallengeResourceRecords(cr)
+	err = r.DeleteAcmeChallengeResourceRecords(reqLogger, cr)
 	if err != nil {
-		log.Error(err, "Error occurred deleting acme challenge resource records from Route53")
-		return err
+		reqLogger.Error(err, "Error occurred deleting acme challenge resource records from Route53")
 	}
 
 	return nil

--- a/pkg/controller/certificaterequest/update_status.go
+++ b/pkg/controller/certificaterequest/update_status.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
 )
 
-func (r *ReconcileCertificateRequest) updateStatus(cr *certmanv1alpha1.CertificateRequest) error {
+func (r *ReconcileCertificateRequest) updateStatus(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) error {
 
 	if cr != nil {
 		certificate, err := GetCertificate(r.client, cr)
@@ -32,7 +33,7 @@ func (r *ReconcileCertificateRequest) updateStatus(cr *certmanv1alpha1.Certifica
 		}
 
 		if certificate == nil {
-			return fmt.Errorf("certificate is nil")
+			return fmt.Errorf("no certificate found")
 		}
 
 		if !cr.Status.Issued ||
@@ -49,7 +50,7 @@ func (r *ReconcileCertificateRequest) updateStatus(cr *certmanv1alpha1.Certifica
 
 			err := r.client.Status().Update(context.TODO(), cr)
 			if err != nil {
-				log.Error(err, err.Error())
+				reqLogger.Error(err, err.Error())
 				return err
 			}
 		}

--- a/pkg/controller/clusterdeployment/clusterdeployment_delete.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_delete.go
@@ -20,7 +20,7 @@ func (r *ReconcileClusterDeployment) handleDelete(cd *hivev1alpha1.ClusterDeploy
 
 	// delete the  certificaterequests
 	for _, deleteCR := range currentCRs {
-		logger.Info(fmt.Sprintf("Deleting CertificateRequest resource config %q", deleteCR.Name))
+		logger.Info(fmt.Sprintf("deleting CertificateRequest resource config %v", deleteCR.Name))
 		if err := r.client.Delete(context.TODO(), &deleteCR); err != nil {
 			logger.Error(err, "error deleting CertificateRequest", "certrequest", deleteCR.Name)
 			return err


### PR DESCRIPTION
By using request logger, all logging statements can now be tied to a particular request. This will help in debugging any issues that may come up. This resolves https://github.com/openshift/certman-operator/issues/32

Signed-off-by: Tejas Parikh <tparikh@redhat.com>