### PR TITLE
Added fields for webconsole URL and API URL to certificate creation

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -229,6 +229,7 @@ func (r *ReconcileClusterDeployment) syncCertificateRequests(cd *hivev1alpha1.Cl
 		} else {
 			// update or no update needed
 			if !reflect.DeepEqual(currentCR.Spec, desiredCR.Spec) {
+				currentCR.Spec = desiredCR.Spec
 				if err := r.client.Update(context.TODO(), currentCR); err != nil {
 					logger.Error(err, "error updating certificaterequest", "certrequest", currentCR.Name)
 					return err
@@ -331,8 +332,10 @@ func createCertificateRequest(certBundleName string, secretName string, domains 
 					},
 				},
 			},
-			DnsNames: domains,
-			Email:    emailAddress,
+			DnsNames:      domains,
+			Email:         emailAddress,
+			APIURL:        cd.Status.APIURL,
+			WebConsoleURL: cd.Status.WebConsoleURL,
 		},
 	}
 


### PR DESCRIPTION
Set API URL and Web Console URL fields for the new certificate requests. These added fields will allow us to check the certificates installed on the cluster and the certificates from the secret stored on Hive cluster with greater ease. Also fixed bug in Sync Certificate Request function in Reconcile loop to ensure that Current CR Spec is set to the value of the Desired CR Spec.
