### PR TITLE
Added metric for runtime of issue certificate function

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -120,6 +120,7 @@ func main() {
 		WithCollectors(localmetrics.MetricCertsIssuedInLastWeekOpenshiftCom).
 		WithCollectors(localmetrics.MetricCertsIssuedInLastWeekOpenshiftAppsCom).
 		WithCollectors(localmetrics.MetricDuplicateCertsIssuedInLastWeek).
+		WithCollectors(localmetrics.MetricIssueCertificateDuration).
 		GetConfig()
 
 	// Configure metrics if it errors log the error but continue

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -37,7 +37,7 @@ import (
 
 func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest, certificateSecret *corev1.Secret) error {
 	timer := prometheus.NewTimer(localmetrics.MetricIssueCertificateDuration)
-	defer localmetrics.UpdateCertificateCreationDurationMetric(timer.ObserveDuration())
+	defer localmetrics.UpdateCertificateIssueDurationMetric(timer.ObserveDuration())
 	proceed, err := r.ValidateDnsWriteAccess(reqLogger, cr)
 	if err != nil {
 		return err

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/eggsampler/acme"
 	"github.com/go-logr/logr"
+	"github.com/openshift/certman-operator/pkg/localmetrics"
+	"github.com/prometheus/client_golang/prometheus"
 
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
 	"github.com/openshift/certman-operator/pkg/controller/controllerutils"
@@ -34,6 +36,8 @@ import (
 )
 
 func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest, certificateSecret *corev1.Secret) error {
+	timer := prometheus.NewTimer(localmetrics.MetricIssueCertificateDuration)
+	defer localmetrics.UpdateCertificateCreationDurationMetric(timer.ObserveDuration())
 	proceed, err := r.ValidateDnsWriteAccess(reqLogger, cr)
 	if err != nil {
 		return err

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -41,6 +41,10 @@ var (
 		Name: "certman_operator_duplicate_certs_in_last_week",
 		Help: "Report how many certs have had duplicate issues",
 	}, []string{"name"})
+	MetricIssueCertificateDuration = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "certman_operator_certificate_creation_duration",
+		Help: "Runtime of issue certificate function in seconds",
+	})
 
 	MetricsList = []prometheus.Collector{
 		MetricCertsIssuedInLastDayOpenshiftCom,
@@ -48,6 +52,7 @@ var (
 		MetricCertsIssuedInLastWeekOpenshiftCom,
 		MetricCertsIssuedInLastWeekOpenshiftAppsCom,
 		MetricDuplicateCertsIssuedInLastWeek,
+		MetricIssueCertificateDuration,
 	}
 )
 
@@ -87,4 +92,8 @@ func UpdateMetrics(hour int) {
 		UpdateCertsIssuedInLastWeekGuage()
 		UpdateDuplicateCertsIssuedInLastWeek()
 	}
+}
+
+func UpdateCertificateCreationDurationMetric(time time.Duration) {
+	MetricIssueCertificateDuration.Observe(float64(time.Seconds()))
 }

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -42,8 +42,9 @@ var (
 		Help: "Report how many certs have had duplicate issues",
 	}, []string{"name"})
 	MetricIssueCertificateDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "certman_operator_certificate_creation_duration",
-		Help: "Runtime of issue certificate function in seconds",
+		Name:        "certman_operator_certificate_issue_duration",
+		Help:        "Runtime of issue certificate function in seconds",
+		ConstLabels: prometheus.Labels{"name": "certman-operator"},
 	})
 
 	MetricsList = []prometheus.Collector{
@@ -56,8 +57,8 @@ var (
 	}
 )
 
-// UpdateCertsIssuedInLastDayGuage sets the gauge metric with the number of certs issued in last day
-func UpdateCertsIssuedInLastDayGuage() {
+// UpdateCertsIssuedInLastDayGauge sets the gauge metric with the number of certs issued in last day
+func UpdateCertsIssuedInLastDayGauge() {
 
 	//Set these to certman calls
 	openshiftCertCount := GetCountOfCertsIssued("openshift.com", 1)
@@ -68,7 +69,7 @@ func UpdateCertsIssuedInLastDayGuage() {
 }
 
 // UpdateCertsIssuedInLastWeekGuage sets the gauge metric with the number of certs issued in last week
-func UpdateCertsIssuedInLastWeekGuage() {
+func UpdateCertsIssuedInLastWeekGauge() {
 
 	//Set these to certman calls
 	openshiftCertCount := GetCountOfCertsIssued("openshift.com", 7)
@@ -88,12 +89,12 @@ func UpdateMetrics(hour int) {
 
 	d := time.Duration(hour) * time.Hour
 	for range time.Tick(d) {
-		UpdateCertsIssuedInLastDayGuage()
-		UpdateCertsIssuedInLastWeekGuage()
+		UpdateCertsIssuedInLastDayGauge()
+		UpdateCertsIssuedInLastWeekGauge()
 		UpdateDuplicateCertsIssuedInLastWeek()
 	}
 }
 
-func UpdateCertificateCreationDurationMetric(time time.Duration) {
+func UpdateCertificateIssueDurationMetric(time time.Duration) {
 	MetricIssueCertificateDuration.Observe(float64(time.Seconds()))
 }


### PR DESCRIPTION
Added metric to record the time (in seconds) for the certificate to be created (the time of the issue certificate function). This metric will allow us to create an alert if this time is over 15 minutes. 