### PR TITLE
Added metric for days until certificate expiry

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -121,6 +121,7 @@ func main() {
 		WithCollectors(localmetrics.MetricCertsIssuedInLastWeekOpenshiftAppsCom).
 		WithCollectors(localmetrics.MetricDuplicateCertsIssuedInLastWeek).
 		WithCollectors(localmetrics.MetricIssueCertificateDuration).
+		WithCollectors(localmetrics.MetricCertificateDaysUntilExpiration).
 		GetConfig()
 
 	// Configure metrics if it errors log the error but continue

--- a/pkg/controller/certificaterequest/renew_certificate.go
+++ b/pkg/controller/certificaterequest/renew_certificate.go
@@ -60,10 +60,6 @@ func (r *ReconcileCertificateRequest) ShouldRenewOrReIssue(reqLogger logr.Logger
 		timeDiff := notAfter.Sub(currentTime)
 		daysCertificateValidFor := int(timeDiff.Hours() / 24)
 		shouldRenew := daysCertificateValidFor <= renewBeforeDays
-		certSerialNum := certificate.SerialNumber
-
-		localmetrics.UpdateCertExpiryDateMetric(cr.Spec.WebConsoleURL, certSerialNum, daysCertificateValidFor)
-
 		localmetrics.UpdateCertExpiryDateMetric(cr.Name, cr.Spec.ACMEDNSDomain, daysCertificateValidFor)
 
 		if shouldRenew {

--- a/pkg/controller/certificaterequest/renew_certificate.go
+++ b/pkg/controller/certificaterequest/renew_certificate.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
+	"github.com/openshift/certman-operator/pkg/localmetrics"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -59,6 +60,9 @@ func (r *ReconcileCertificateRequest) ShouldRenewOrReIssue(reqLogger logr.Logger
 		timeDiff := notAfter.Sub(currentTime)
 		daysCertificateValidFor := int(timeDiff.Hours() / 24)
 		shouldRenew := daysCertificateValidFor <= renewBeforeDays
+		certSerialNum := certificate.SerialNumber
+
+		localmetrics.UpdateCertExpiryDateMetric(cr.Spec.WebConsoleURL, certSerialNum, daysCertificateValidFor)
 
 		if shouldRenew {
 			reqLogger.Info(fmt.Sprintf("certificate is valid from (notBefore) %v and until (notAfter) %v and is valid for %d days and will be renewed", certificate.NotBefore.String(), certificate.NotAfter.String(), daysCertificateValidFor))

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -107,5 +107,5 @@ func UpdateCertificateIssueDurationMetric(time time.Duration) {
 
 //Sets gauge metric for certificate expiry with certificate serial number, the days until expiry, and corresponding cluster name
 func UpdateCertExpiryDateMetric(clusterNameURL string, certSerialNum *big.Int, daysCertValidFor int) {
-	MetricCertificateDaysUntilExpiration.With(prometheus.Labels{"name": "certman-operator", "clusterURL": clusterNameURL, "certificiate-serial-num": certSerialNum.String()}).Set(float64(daysCertValidFor))
+	MetricCertificateDaysUntilExpiration.With(prometheus.Labels{"name": "certman-operator", "clusterURL": clusterNameURL, "certificate-serial-num": certSerialNum.String()}).Set(float64(daysCertValidFor))
 }

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -47,8 +47,8 @@ var (
 		Help:        "Runtime of issue certificate function in seconds",
 		ConstLabels: prometheus.Labels{"name": "certman-operator"},
 	})
-	MetricCertificateExpirations = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "certman_operator_certificate_expiring",
+	MetricCertificateDaysUntilExpiration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "certman_operator_certificate_days_valid_until_expiration",
 		Help: "Report the number of days until a certificate expires with the certificate serial number and corresponding cluster name",
 	}, []string{"name"})
 
@@ -59,7 +59,7 @@ var (
 		MetricCertsIssuedInLastWeekOpenshiftAppsCom,
 		MetricDuplicateCertsIssuedInLastWeek,
 		MetricIssueCertificateDuration,
-		MetricCertificateExpirations,
+		MetricCertificateDaysUntilExpiration,
 	}
 )
 
@@ -107,5 +107,5 @@ func UpdateCertificateIssueDurationMetric(time time.Duration) {
 
 //Sets gauge metric for certificate expiry with certificate serial number, the days until expiry, and corresponding cluster name
 func UpdateCertExpiryDateMetric(clusterNameURL string, certSerialNum *big.Int, daysCertValidFor int) {
-	MetricCertificateExpirations.With(prometheus.Labels{"name": "certman-operator", "clusterURL": clusterNameURL, "certificiate-serial-num": certSerialNum.String()}).Set(float64(daysCertValidFor))
+	MetricCertificateDaysUntilExpiration.With(prometheus.Labels{"name": "certman-operator", "clusterURL": clusterNameURL, "certificiate-serial-num": certSerialNum.String()}).Set(float64(daysCertValidFor))
 }


### PR DESCRIPTION
Added a metric for the number of days a certificate is valid for (until expiry), with labels for the certificate serial number and the corresponding cluster URL. This metric will allow us to create an alert for when the certificate expiry date is within a certain # of days (for example, send an alert if a certificate is expiring in the next 15 days) 