### PR TITLE
adding 'Status: Success' to finalized certficateRequests

### DIFF
--- a/pkg/controller/certificaterequest/update_status.go
+++ b/pkg/controller/certificaterequest/update_status.go
@@ -42,13 +42,15 @@ func (r *ReconcileCertificateRequest) updateStatus(reqLogger logr.Logger, cr *ce
 			cr.Status.IssuerName != certificate.Issuer.CommonName ||
 			cr.Status.NotBefore != certificate.NotBefore.String() ||
 			cr.Status.NotAfter != certificate.NotAfter.String() ||
-			cr.Status.SerialNumber != certificate.SerialNumber.String() {
+			cr.Status.SerialNumber != certificate.SerialNumber.String() ||
+			cr.Status.Status != "Success" {
 
 			cr.Status.Issued = true
 			cr.Status.IssuerName = certificate.Issuer.CommonName
 			cr.Status.NotBefore = certificate.NotBefore.String()
 			cr.Status.NotAfter = certificate.NotAfter.String()
 			cr.Status.SerialNumber = certificate.SerialNumber.String()
+			cr.Status.Status = "Success"
 
 			err := r.client.Status().Update(context.TODO(), cr)
 			if err != nil {


### PR DESCRIPTION
This will clearly indicate when certs have been issued and remove any prior error states. Conditions that were errors will remain.