### PR TITLE
Simplify let's encrypt staging/production env setup

### DIFF
--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/openshift/certman-operator/config"
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
-	"github.com/openshift/certman-operator/pkg/controller/controllerutils"
 	"github.com/openshift/certman-operator/pkg/leclient"
 
 	corev1 "k8s.io/api/core/v1"
@@ -48,14 +47,18 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 		reqLogger.Info("permissions for Route53 has been validated")
 	}
 
-	useLetsEncryptStagingEndpoint := controllerutils.UsetLetsEncryptStagingEnvironment(r.client)
-
-	if useLetsEncryptStagingEndpoint {
-		reqLogger.Info("operator is configured to use Let's Encrypt staging environment.")
+	url, err := leclient.GetLetsEncryptDirctoryURL(r.client)
+	if err != nil {
+		reqLogger.Error(err, "failed to get letsencrypt directory url")
+		return err
 	}
 
-	leClient, err := leclient.GetLetsEncryptClient(useLetsEncryptStagingEndpoint)
-	err = leClient.GetAccount(r.client, useLetsEncryptStagingEndpoint, config.OperatorNamespace)
+	leClient, err := leclient.GetLetsEncryptClient(url)
+	if err != nil {
+		reqLogger.Error(err, "failed to get letsencrypt client")
+		return err
+	}
+	err = leClient.GetAccount(r.client, config.OperatorNamespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controllerutils/configmap.go
+++ b/pkg/controller/controllerutils/configmap.go
@@ -38,19 +38,6 @@ func GetConfig(kubeClient client.Client) (*corev1.ConfigMap, error) {
 	return cm, nil
 }
 
-func UsetLetsEncryptStagingEnvironment(kubeClient client.Client) bool {
-	cm, err := GetConfig(kubeClient)
-	if err != nil {
-		return true
-	}
-
-	if cm.Data["lets_encrypt_environment"] == "staging" || cm.Data["lets_encrypt_environment"] == "" {
-		return true
-	}
-
-	return false
-}
-
 func GetDefaultNotificationEmailAddress(kubeClient client.Client) (string, error) {
 	cm, err := GetConfig(kubeClient)
 	if err != nil {

--- a/pkg/leclient/constants.go
+++ b/pkg/leclient/constants.go
@@ -19,8 +19,11 @@ package leclient
 const (
 	letsEncryptAccountPrivateKey           = "private-key"
 	letsEncryptAccountUrl                  = "account-url"
-	letsEncryptProductionAccountSecretName = "lets-encrypt-account-production"
-	LetsEncryptCertIssuingAuthority        = "Let's Encrypt Authority X3"
-	letsEncryptStagingAccountSecretName    = "lets-encrypt-account-staging"
 	StagingLetsEncryptCertIssuingAuthority = "Fake LE Intermediate X1"
+	LetsEncryptCertIssuingAuthority        = "Let's Encrypt Authority X3"
+	// Deprecated, use letsEncryptAccountSecretName instead
+	letsEncryptProductionAccountSecretName = "lets-encrypt-account-production"
+	// Deprecated, use letsEncryptAccountSecretName instead
+	letsEncryptStagingAccountSecretName = "lets-encrypt-account-staging"
+	letsEncryptAccountSecretName        = "lets-encrypt-account"
 )


### PR DESCRIPTION
After this:
1.  we do not need set lets_encrypt_environment=staging in the certman-operator configmap, we will get the lets encrypt directory url according to the account-url.
2. we need create "lets-encrypt-account" secret instead of "lets-encrypt-account-staging" and "lets-encrypt-account-production", but for backward compatability, if "let's-encrypt-account" secret is not there, it will try to use "lets-enctrypt-account-production", then "lets-encrypt-account-staging".