### PR TITLE
Correct service name to match whats on cluster and in monitoring

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
+	operatorconfig "github.com/openshift/certman-operator/config"
 	"github.com/openshift/certman-operator/pkg/apis"
 	"github.com/openshift/certman-operator/pkg/controller"
 	"github.com/openshift/certman-operator/pkg/localmetrics"
@@ -124,6 +125,7 @@ func main() {
 	metricsServer := metrics.NewBuilder().WithPort(metricsPort).WithPath(metricsPath).
 		WithCollectors(localmetrics.MetricsList).
 		WithRoute().
+		WithServiceName(operatorconfig.OperatorName).
 		GetConfig()
 
 	// Configure metrics. If it errors, log the error but continue.


### PR DESCRIPTION
Before, the service name defaulted to the name of the operator, which the route creation used for the route name. However, other services may already be created with the name name, so a default name was built in to the library. This PR explicitly uses the name of the operator for the service to match the service/route names our current monitoring set up expects.

See this PR for the same fix https://github.com/openshift/aws-account-operator/pull/177