### PR TITLE
SREP 2035 - detect up local

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,12 @@
 approvers:
-- tparikh
+- RiRa12621
+- drewandersonnz
+- c-e-brumm
 - jharrington22
+- rogbas
 - jewzaam
 - mwoodson
-- c-e-brumm
+- tparikh
 reviewers:
 - jewzaam
 - mwoodson

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -128,12 +128,16 @@ func main() {
 		WithServiceName(operatorconfig.OperatorName).
 		GetConfig()
 
-	// Configure metrics. If it errors, log the error but continue.
-	if err := metrics.ConfigureMetrics(context.TODO(), *metricsServer); err != nil {
-		log.Error(err, "Failed to configure Metrics")
-		os.Exit(1)
-	}
+	// detect if operator-sdk up local is run
+	detectLocal := os.Getenv("OPERATOR_UP_LOCAL")
 
+	// Configure metrics. If it errors, log the error but continue.
+	if detectLocal != "true" {
+		if err := metrics.ConfigureMetrics(context.TODO(), *metricsServer); err != nil {
+			log.Error(err, "Failed to configure Metrics")
+			os.Exit(1)
+		}
+	}
 	// Invoke UpdateMetrics at a frequency defined as hours within a goroutine.
 	go localmetrics.UpdateMetrics(hours)
 	log.Info("Starting the Cmd.")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
+	operatorconfig "github.com/openshift/certman-operator/config"
 	"github.com/openshift/certman-operator/pkg/apis"
 	"github.com/openshift/certman-operator/pkg/controller"
 	"github.com/openshift/certman-operator/pkg/localmetrics"
@@ -124,6 +125,7 @@ func main() {
 	metricsServer := metrics.NewBuilder().WithPort(metricsPort).WithPath(metricsPath).
 		WithCollectors(localmetrics.MetricsList).
 		WithRoute().
+		WithServiceName(operatorconfig.OperatorName).
 		GetConfig()
 
 	// Configure metrics. If it errors, log the error but continue.

--- a/pkg/controller/certificaterequest/dns.go
+++ b/pkg/controller/certificaterequest/dns.go
@@ -198,7 +198,7 @@ func (r *ReconcileCertificateRequest) DeleteAcmeChallengeResourceRecords(reqLogg
 			if !*zone.HostedZone.Config.PrivateZone {
 
 				for _, domain := range cr.Spec.DnsNames {
-
+					// Format domain strings, no leading '*', must lead with '.'
 					domain = strings.TrimPrefix(domain, "*")
 					if !strings.HasPrefix(domain, ".") {
 						domain = "." + domain

--- a/pkg/controller/certificaterequest/dns.go
+++ b/pkg/controller/certificaterequest/dns.go
@@ -200,7 +200,9 @@ func (r *ReconcileCertificateRequest) DeleteAcmeChallengeResourceRecords(reqLogg
 				for _, domain := range cr.Spec.DnsNames {
 
 					domain = strings.TrimPrefix(domain, "*")
-
+					if !strings.HasPrefix(domain, ".") {
+						domain = "." + domain
+					}
 					fqdn := acmeChallengeSubDomain + domain
 					fqdnWithDot := fqdn + "."
 
@@ -215,14 +217,11 @@ func (r *ReconcileCertificateRequest) DeleteAcmeChallengeResourceRecords(reqLogg
 					if err != nil {
 						return err
 					}
-
 					if len(resp.ResourceRecordSets) > 0 &&
 						*resp.ResourceRecordSets[0].Name == fqdnWithDot &&
 						*resp.ResourceRecordSets[0].Type == route53.RRTypeTxt &&
 						len(resp.ResourceRecordSets[0].ResourceRecords) > 0 {
-
 						for _, rr := range resp.ResourceRecordSets[0].ResourceRecords {
-
 							input := &route53.ChangeResourceRecordSetsInput{
 								ChangeBatch: &route53.ChangeBatch{
 									Changes: []*route53.Change{


### PR DESCRIPTION
If operator-framework/operator-sdk#2063 is
accepted. This PR would allow certman-operator to detect if its being
called locally by the SDK and skip bootstrapping tasks like registering
for metrics.