### PR TITLE
Delete after use

### DIFF
--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -195,5 +195,10 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 
 	reqLogger.Info("certificates are now available")
 
+	err = r.DeleteAcmeChallengeResourceRecords(reqLogger, cr)
+	if err != nil {
+		reqLogger.Error(err, "error occurred deleting acme challenge resource records from Route53")
+	}
+
 	return nil
 }

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -195,6 +195,8 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 
 	reqLogger.Info("certificates are now available")
 
+	// After resolving all new challenges, and storing the cert, delete the challenge records
+	// that were used from dns in this zone.
 	err = r.DeleteAcmeChallengeResourceRecords(reqLogger, cr)
 	if err != nil {
 		reqLogger.Error(err, "error occurred deleting acme challenge resource records from Route53")


### PR DESCRIPTION
Deletes the acme challenge records after retrieving the cert they were made for. Challenge records do not need to exist after the challenge has been completed.