### PR TITLE
Delete all acme challenge records

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -79,7 +79,7 @@ func (c *awsClient) ListResourceRecordSets(input *route53.ListResourceRecordSets
 	return c.route53Client.ListResourceRecordSets(input)
 }
 
-// Function for finding a hostedzone when given an aws client and a domain string
+// SearchForHostedZone finds a hostedzone when given an aws client and a domain string
 // Returns a hostedzone object
 func SearchForHostedZone(r53svc Client, baseDomain string) (hostedZone route53.HostedZone, err error) {
 	hostedZoneOutput, err := r53svc.ListHostedZones(&route53.ListHostedZonesInput{})
@@ -95,7 +95,7 @@ func SearchForHostedZone(r53svc Client, baseDomain string) (hostedZone route53.H
 	return hostedZone, err
 }
 
-// Contructs an Input object for a hostedzone. Contains no recordsets.
+// BuildR53Input contructs an Input object for a hostedzone. Contains no recordsets.
 func BuildR53Input(hostedZone string) *route53.ChangeResourceRecordSetsInput {
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
@@ -106,7 +106,8 @@ func BuildR53Input(hostedZone string) *route53.ChangeResourceRecordSetsInput {
 	return input
 }
 
-// Creates an route53 Change object for a TXT record with a given name and given action to take.
+// CreateR53TXTRecordChange creates an route53 Change object for a TXT record with a given name
+// and a given action to take.
 func CreateR53TXTRecordChange(name *string, action string, value *string) route53.Change {
 	change := route53.Change{
 		Action: aws.String(route53.ChangeActionDelete),

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -108,9 +108,18 @@ func BuildR53Input(hostedZone string) *route53.ChangeResourceRecordSetsInput {
 
 // CreateR53TXTRecordChange creates an route53 Change object for a TXT record with a given name
 // and a given action to take.
-func CreateR53TXTRecordChange(name *string, action string, value *string) route53.Change {
-	change := route53.Change{
-		Action: aws.String(route53.ChangeActionDelete),
+func CreateR53TXTRecordChange(name *string, action string, value *string) (change route53.Change, err error) {
+	if strings.EqualFold("DELETE", action) {
+		action = route53.ChangeActionDelete
+	} else if strings.EqualFold("CREATE", action) {
+		action = route53.ChangeActionCreate
+	} else if strings.EqualFold("UPSERT", action) {
+		action = route53.ChangeActionUpsert
+	} else {
+		return change, fmt.Errorf("Invaild record action passed %v. Must be DELETE, CREATE, or UPSERT", action)
+	}
+	change = route53.Change{
+		Action: aws.String(action),
 		ResourceRecordSet: &route53.ResourceRecordSet{
 			Name: aws.String(*name),
 			ResourceRecords: []*route53.ResourceRecord{
@@ -122,7 +131,7 @@ func CreateR53TXTRecordChange(name *string, action string, value *string) route5
 			Type: aws.String(route53.RRTypeTxt),
 		},
 	}
-	return change
+	return change, nil
 }
 
 // NewClient returns an awsclient.Client object to the caller. If NewClient is passed a non-null

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -107,8 +107,10 @@ func BuildR53Input(hostedZone string) *route53.ChangeResourceRecordSetsInput {
 }
 
 // CreateR53TXTRecordChange creates an route53 Change object for a TXT record with a given name
-// and a given action to take.
+// and a given action to take. Valid actions are strings matching valid route53 ChangeActions.
 func CreateR53TXTRecordChange(name *string, action string, value *string) (change route53.Change, err error) {
+	// Checking the string 'action' to see if it matches any of the valid route53 acctions.
+	// If an incorrect string value is passed this function will exit and raise an error.
 	if strings.EqualFold("DELETE", action) {
 		action = route53.ChangeActionDelete
 	} else if strings.EqualFold("CREATE", action) {

--- a/pkg/controller/certificaterequest/dns.go
+++ b/pkg/controller/certificaterequest/dns.go
@@ -312,7 +312,10 @@ func (r *ReconcileCertificateRequest) DeleteAllAcmeChallengeResourceRecords(reqL
 	input := awsclient.BuildR53Input(*hostedzone.Id)
 	for _, record := range listRecordSets.ResourceRecordSets {
 		if strings.Contains(*record.Name, acmeChallengeSubDomain) {
-			change := awsclient.CreateR53TXTRecordChange(record.Name, route53.ChangeActionDelete, record.ResourceRecords[0].Value)
+			change, err := awsclient.CreateR53TXTRecordChange(record.Name, route53.ChangeActionDelete, record.ResourceRecords[0].Value)
+			if err != nil {
+				reqLogger.Error(err, "Error creating record change object")
+			}
 			input.ChangeBatch.Changes = append(input.ChangeBatch.Changes, &change)
 		}
 	}

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -197,7 +197,7 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 
 	// After resolving all new challenges, and storing the cert, delete the challenge records
 	// that were used from dns in this zone.
-	err = r.DeleteAcmeChallengeResourceRecords(reqLogger, cr)
+	err = r.DeleteAllAcmeChallengeResourceRecords(reqLogger, cr)
 	if err != nil {
 		reqLogger.Error(err, "error occurred deleting acme challenge resource records from Route53")
 	}


### PR DESCRIPTION
After completing an acme challenge all acme challenge records for the same hosted zone are deleted. This will ensure that no records are left behind in a zone. And if records are left behind from before they will be cleaned up when the zone is used next.