### PR TITLE
New feature, additional control plane record added to certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ oc create -f deploy/operator.yaml
 
 `certman_operator_duplicate_certs_in_last_week` reports how many certs have had duplication issues.
 
+## Additional record for control plane certificate
+
+Certman Operator always creates a certificate for the control plane for the clusters Hive builds. By passing a string into the pod as an environment variable named `EXTRA_RECORD` Certman Operator can add an additional record to the SAN of the certificate for the API servers. This string should be the short hostname without the domain. The record will use the same domain as the rest of the cluster for this new record.
+Example
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: certman-operator
+spec:
+  template:
+    spec:
+    ...
+      env:
+      - name: EXTRA_RECORD
+        value: "myapi"
+```
+The example will add `myapi.<clustername>.<clusterdomain>` to the certificate of the control plane.
 ## License
 
 Certman Operator is licensed under Apache 2.0 license. See the [LICENSE](LICENSE) file for details.

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -335,11 +335,15 @@ func getDomainsForCertBundle(cb hivev1alpha1.CertificateBundleSpec, cd *hivev1al
 	domains := []string{}
 	dLogger := logger.WithValues("CertificateBundle", cb.Name)
 
-	// first check for the special-case two default control plane references
+	// First check if CertificateBundleSpec.Name matches the default control plane name
 	if cd.Spec.ControlPlaneConfig.ServingCertificates.Default == cb.Name {
+
+		// Add default record for the cluster api
 		controlPlaneCertDomain := fmt.Sprintf("api.%s.%s", cd.Spec.ClusterName, cd.Spec.BaseDomain)
 		dLogger.Info("control plane config DNS name: " + controlPlaneCertDomain)
 		domains = append(domains, controlPlaneCertDomain)
+
+		// Check for extra record option and add to SAN if it's present
 		userDomain := os.Getenv("EXTRA_RECORD")
 		if userDomain != "" {
 			extraDomain := fmt.Sprintf("%s.%s.%s", userDomain, cd.Spec.ClusterName, cd.Spec.BaseDomain)

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -19,6 +19,7 @@ package clusterdeployment
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -334,11 +335,17 @@ func getDomainsForCertBundle(cb hivev1alpha1.CertificateBundleSpec, cd *hivev1al
 	domains := []string{}
 	dLogger := logger.WithValues("CertificateBundle", cb.Name)
 
-	// first check for the special-case default control plane reference
+	// first check for the special-case two default control plane references
 	if cd.Spec.ControlPlaneConfig.ServingCertificates.Default == cb.Name {
 		controlPlaneCertDomain := fmt.Sprintf("api.%s.%s", cd.Spec.ClusterName, cd.Spec.BaseDomain)
 		dLogger.Info("control plane config DNS name: " + controlPlaneCertDomain)
 		domains = append(domains, controlPlaneCertDomain)
+		userDomain := os.Getenv("EXTRA_RECORD")
+		if userDomain != "" {
+			extraDomain := fmt.Sprintf("%s.%s.%s", userDomain, cd.Spec.ClusterName, cd.Spec.BaseDomain)
+			dLogger.Info("RH private control plane config DNS name: " + extraDomain)
+			domains = append(domains, extraDomain)
+		}
 	}
 
 	// now check the rest of the control plane


### PR DESCRIPTION
This will allow Certman Operator owners to specify and additional hostname of the same domain to be added to the certificate of the control plane.