### PR TITLE
changing panic to an error message

### DIFF
--- a/pkg/localmetrics/crt_sh.go
+++ b/pkg/localmetrics/crt_sh.go
@@ -135,12 +135,12 @@ func GetCountOfCertsIssued(domain string, durationDays int) int {
 
 	row := db.QueryRow(GET_COUNT_CERTS_ISSUED_BY_LE_SQL, "%."+domain, certDuration)
 
-	var numCertsIssued int
+	numCertsIssued := 0
 
 	err = row.Scan(&numCertsIssued)
 
 	if err != nil {
-		panic(err)
+		log.Error(err, "Error while parsing crt.sh data")
 	}
 
 	return numCertsIssued


### PR DESCRIPTION
This will stop the logs from being rotated too quickly resulting in lost debug logging.