### PR TITLE
adding config for additional api endpoint to default certs, rh-api.cl…

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -28,3 +28,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "certman-operator"
+            - name: EXTRA_RECORD
+              value: "rh-api"

--- a/pkg/controller/certificaterequest/constants.go
+++ b/pkg/controller/certificaterequest/constants.go
@@ -21,7 +21,7 @@ const (
 	cloudflareRequestContentType      = "application/dns-json"
 	cloudflareRequestTimeout          = 60
 	maxAttemptsForDnsPropogationCheck = 5
-	waitTimePeriodDnsPropogationCheck = 60
+	waitTimePeriodDnsPropogationCheck = 30
 	reissueCertificateBeforeDays      = 45 // This helps us avoid getting email notifications from Let's Encrypt.
 	resourceRecordTTL                 = 60
 	rSAKeyBitSize                     = 2048


### PR DESCRIPTION
…uster. Shortening time waiting on DNS propagation from 60 to 30 seconds.