### PR TITLE
Use ProjectID from serviceaccount

### DIFF
--- a/pkg/clients/client.go
+++ b/pkg/clients/client.go
@@ -30,7 +30,7 @@ func NewClient(kubeClient client.Client, platform certmanv1alpha1.Platform, name
 	if platform.GCP != nil {
 		log.Info("build gcp client")
 		// TODO: Add project as configurable
-		return gcp.NewClient(kubeClient, platform.GCP.Credentials.Name, namespace, "openshift-sd-testing")
+		return gcp.NewClient(kubeClient, platform.GCP.Credentials.Name, namespace)
 	}
 	return nil, fmt.Errorf("Platform not supported")
 }

--- a/pkg/clients/gcp/dns.go
+++ b/pkg/clients/gcp/dns.go
@@ -220,7 +220,7 @@ func (c *gcpClient) DeleteAcmeChallengeResourceRecords(reqLogger logr.Logger, cr
 }
 
 // NewClient reuturn new GCP DNS client
-func NewClient(kubeClient client.Client, secretName, namespace, project string) (*gcpClient, error) {
+func NewClient(kubeClient client.Client, secretName, namespace string) (*gcpClient, error) {
 	ctx := context.Background()
 	secret := &corev1.Secret{}
 	err := kubeClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: secretName}, secret)
@@ -240,6 +240,6 @@ func NewClient(kubeClient client.Client, secretName, namespace, project string) 
 
 	return &gcpClient{
 		client:  *service,
-		project: project,
+		project: config.ProjectID,
 	}, nil
 }


### PR DESCRIPTION
We were previously hardcoding to "openshift-sd-testing". This uses the ProjectID from the provisioned service account.