### PR TITLE
Don't hard error on NXDOMAIN

### DIFF
--- a/pkg/controller/certificaterequest/cloudflare.go
+++ b/pkg/controller/certificaterequest/cloudflare.go
@@ -125,9 +125,10 @@ func ValidateResourceRecordUpdatesUsingCloudflareDNS(reqLogger logr.Logger, name
 		return false, err
 	}
 
+	// If there is no answer field,
 	if len(cloudflareResponse.Answers) == 0 {
-		reqLogger.Error(err, "no answers received from cloudflare")
-		return false, errors.New("no answers received from cloudflare")
+		reqLogger.Info("no answers received from cloudflare; likely not propagated")
+		return false, nil
 	}
 
 	// Name never has a trailing dot but he answer from Cloudflare sometimes does.

--- a/pkg/controller/certificaterequest/constants.go
+++ b/pkg/controller/certificaterequest/constants.go
@@ -20,8 +20,8 @@ const (
 	cloudflareDNSOverHttpsEndpoint    = "https://cloudflare-dns.com/dns-query"
 	cloudflareRequestContentType      = "application/dns-json"
 	cloudflareRequestTimeout          = 60
-	maxAttemptsForDnsPropogationCheck = 5
-	waitTimePeriodDnsPropogationCheck = 30
+	maxAttemptsForDnsPropogationCheck = 10 // Try 10 times (5 minutes total)
+	waitTimePeriodDnsPropogationCheck = 30 // Wait 30 seconds between checks
 	reissueCertificateBeforeDays      = 45 // This helps us avoid getting email notifications from Let's Encrypt.
 	resourceRecordTTL                 = 60
 	rSAKeyBitSize                     = 2048


### PR DESCRIPTION
Right now, if we get an NXDOMAIN (domain doesn't exist) when checking for propagation, we throw a hard error, causing us to retry the whole validation process.

In the case of a new cluster, where DNS propagation takes awhile, NXDOMAIN is expected initially. If we hard error, then we create a whole new DNS record causing the validation to never succeed.