### PR TITLE
Split operations into separate functions

### DIFF
--- a/pkg/clients/types/types.go
+++ b/pkg/clients/types/types.go
@@ -1,5 +1,6 @@
 package types
 
 const (
-	AcmeChallengeSubDomain = "_acme-challenge"
+	AcmeChallengeSubDomain   = "_acme-challenge"
+	WriteValidationSubDomain = "_certman_access_test"
 )


### PR DESCRIPTION
This splits a few reusable GCP operations into separate functions:
- Any time we need to determine the managed zone, we are now using `getManagedZone`
- If we are adding a record, we'll use `upsertDnsRecord`, and if we delete we will use `deleteDnsRecords`
- The upsert function will check if a record of the same type/name exists, and replace it. This will allow certman to use a new challenge, if the previous challenge hasn't been cleaned up.