### PR TITLE
Revert "Merge pull request #136 from bmeng/resourcelimit"

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,13 +19,6 @@ spec:
           command:
           - certman-operator
           imagePullPolicy: Always
-          resources:
-            requests:
-              memory: "150Mi"
-              cpu: "10m"
-            limits:
-              memory: "300Mi"
-              cpu: "30m"
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
Reverts https://github.com/openshift/certman-operator/pull/136. These limits are super low, and we need to discuss them further.

This reverts commit d1bd11ae5a07f98d403c0999651313fc9da7c6bc, reversing
changes made to 426bf98ba88061fb4d7dda6a925653e7d0765dcc.