### PR TITLE
Fix Dns zone type check

### DIFF
--- a/pkg/clients/azure/dns.go
+++ b/pkg/clients/azure/dns.go
@@ -140,7 +140,7 @@ func (c *azureClient) ValidateDNSWriteAccess(reqLogger logr.Logger, cr *certmanv
 
 	recordKey := "_certman_access_test." + *zone.Name
 
-	if zone.ZoneType != "Private" {
+	if zone.ZoneType == "Private" {
 		reqLogger.Error(err, "Private DNS zone is not allowed")
 		return false, nil
 	}


### PR DESCRIPTION
This PR fixes a bug in azure support where it only allows using private hosted zone whereas it should actually allow only public hosted zones.

The bug was introduced in https://github.com/openshift/certman-operator/pull/146