### PR TITLE
Update README, remove vestigial lets_encrypt_environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,48 +5,73 @@
 [![codecov](https://codecov.io/gh/openshift/certman-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/openshift/certman-operator)
 [![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
+- [certman-operator](#certman-operator)
+  - [About](#about)
+  - [Dependencies](#dependencies)
+  - [How the Certman Operator works](#how-the-certman-operator-works)
+  - [Limitations](#limitations)
+  - [CustomResourceDefinitions](#customresourcedefinitions)
+  - [Setup Certman Operator](#setup-certman-operator)
+    - [Local development testing](#local-development-testing)
+    - [Certman Operator Configuration](#certman-operator-configuration)
+    - [Certman Operator Secrets](#certman-operator-secrets)
+    - [Custom Resource Definitions (CRDs)](#custom-resource-definitions-crds)
+      - [Create Hive CRDs](#create-hive-crds)
+      - [Create Certman Operator CRDs](#create-certman-operator-crds)
+    - [Run Operator From Source](#run-operator-from-source)
+    - [Build Operator Image](#build-operator-image)
+    - [Setup & Deploy Operator On OpenShift/Kubernetes Cluster](#setup--deploy-operator-on-openshiftkubernetes-cluster)
+      - [Create & Use OpenShift Project](#create--use-openshift-project)
+      - [Setup Service Account](#setup-service-account)
+      - [Setup RBAC](#setup-rbac)
+      - [Deploy the Operator](#deploy-the-operator)
+  - [Metrics](#metrics)
+  - [Additional record for control plane certificate](#additional-record-for-control-plane-certificate)
+  - [License](#license)
+
 ## About
 The Certman Operator is used to automate the provisioning and management of TLS certificates from [Let's Encrypt](https://letsencrypt.org/) for [OpenShift Dedicated](https://www.openshift.com/products/dedicated/) clusters provisioned via https://cloud.redhat.com/.
 
 At a high level, Certman Operator is responsible for:
 
-* Provisioning Certificates after a clusters successful installation.
+* Provisioning Certificates after a cluster's successful installation.
 * Reissuing Certificates prior to their expiry.
 * Revoking Certificates upon cluster decomissioning.
 
 ## Dependencies
 
-**GO:** 1.11
+**GO:** 1.13
 
-**Operator-SDK:** 0.5.0
+**Operator-SDK:** 0.16.0
 
-**Hive** v1
-Certman Operator is currently dependent on [Hive](https://github.com/openshift/hive). Hive is an API driven OpenShift cluster providing OpenShift Dedicated provisioning and management.
+**Hive:** v1
 
-Specifically, Hive provides a [namespace scoped](https://github.com/openshift/hive/blob/master/config/crds/hive_v1_clusterdeployment.yaml#L34) [CustomResourceDefinition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) called [ClusterDeployment](https://github.com/openshift/hive/blob/master/config/crds/hive_v1_clusterdeployment.yaml). Certman watches the `Installed` spec of CRD and will attempt to [provision certificates](https://github.com/openshift/certman-operator/blob/master/pkg/controller/clusterdeployment/clusterdeployment_controller.go#L134) for the cluster once this field returns `true`. Hive is also responsible for the deployment of the certificates to the cluster via [syncsets](https://github.com/openshift/hive/blob/master/docs/syncset.md).
+Certman Operator is currently dependent on [Hive](https://github.com/openshift/hive). Hive is an API-driven OpenShift operator providing OpenShift Dedicated cluster provisioning and management.
+
+Specifically, Hive provides a [namespace scoped](https://github.com/openshift/hive/blob/bb68a3046b812a718aaf9cd5fe4380f80fb2bcd9/config/crds/hive.openshift.io_clusterdeployments.yaml#L34) [CustomResourceDefinition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) called [ClusterDeployment](https://github.com/openshift/hive/blob/bb68a3046b812a718aaf9cd5fe4380f80fb2bcd9/config/crds/hive.openshift.io_clusterdeployments.yaml). Certman watches the `Installed` spec of instances of that CRD and will attempt to provision certificates for the cluster once this field returns `true`. Hive is also responsible for the deployment of the certificates to the cluster via [syncsets](https://github.com/openshift/hive/blob/master/docs/syncset.md).
 
 Only Hive v1 will work with this release.
 
 ## How the Certman Operator works
 
-1. A new OpenShift Dedicated cluster is requested by from https://cloud.redhat.com.
-1. Certman's `Reconcile` function watches the `Installed` field of the ClusterDeployment CRD (as explained above). Once the `Installed` field becomes `true`, a [CertificateRequest](https://github.com/openshift/certman-operator/blob/master/deploy/crds/certman_v1alpha1_certificaterequest_crd.yaml) resource is created for that cluster.
+1. A new OpenShift Dedicated cluster is requested from https://cloud.redhat.com.
+1. The clusterdeployment controller's `Reconcile` function watches the `Installed` field of the ClusterDeployment CRD (as explained above). Once the `Installed` field becomes `true`, a [CertificateRequest](https://github.com/openshift/certman-operator/blob/master/deploy/crds/certman_v1alpha1_certificaterequest_crd.yaml) resource is created for that cluster.
 1. Certman operator will then request new certificates from Let’s Encrypt based on the populated spec fields of the CertificateRequest CRD.
 1. To prove ownership of the domain, Certman will attempt to answer the Let’s Encrypt [DNS-01 challenge](https://letsencrypt.org/docs/challenge-types/) by publishing the `_acme-challenge` subdomain in the cluster’s DNS zone with a TTL of 1 min.
 1. Wait for propagation of the record and then verify the existance of the challenge subdomain by using DNS over HTTPS service from Cloudflare. Certman will retry verification up to 5 times before erroring.
 1. Once the challenge subdomain record has been verified, Let’s Encrypt can verify that you are in control of the domain’s DNS.
-1. Let’s Encrypt will issue certificates once challenge has been successfuly completed. Certman will then delete the challenge subdomain as it is no longer required.
-1. Certificates are then stored in a secret on the management cluster. Hive watchs for this secret.
-1. Once the secret contains a valid certificates for the cluster, Hive will sync the secrets over to the OpenShift Dedicated cluster using a [SyncSet](https://github.com/openshift/hive/blob/master/docs/syncset.md).
-1. Certman operator will reconcile all CertificateRequest every 10 minutes by default. During this reconciliation loop, certman will check for the validity of the existing certificates. As the certificates expiry nears 45 days, they will be reissued and the secret will be updated. Reissuing certificates this early avoids getting email notifications about certificate expiry from Let’s Encrypt.
+1. Let’s Encrypt will issue certificates once the challenge has been successfuly completed. Certman will then delete the challenge subdomain as it is no longer required.
+1. Certificates are then stored in a secret on the management cluster. Hive watches for this secret.
+1. Once the secret contains valid certificates for the cluster, Hive will sync the secrets over to the OpenShift Dedicated cluster using a [SyncSet](https://github.com/openshift/hive/blob/master/docs/syncset.md).
+1. Certman operator will reconcile all CertificateRequests every 10 minutes by default. During this reconciliation loop, certman will check for the validity of the existing certificates. As the certificate's expiry nears 45 days, they will be reissued and the secret will be updated. Reissuing certificates this early avoids getting email notifications about certificate expiry from Let’s Encrypt.
 1. Updates to secrets on certificate reissuance will trigger Hive controller’s reconciliation loop which will force a syncset of the new secret to the OpenShift Dedicated cluster. OpenShift will detect that secret has changed and will apply the new certificates to the cluster.
-1. When a OpenShift Dedicated cluster is decommissioned, all valid certificates are first revoked and then the secret is deleted on the management cluster. Hive will then continue deleting other cluster resources.
+1. When an OpenShift Dedicated cluster is decommissioned, all valid certificates are first revoked and then the secret is deleted on the management cluster. Hive will then continue deleting the other cluster resources.
 
 ## Limitations
 
-* As described above in dependencies, Certman Operator requires [Hive](https://github.com/openshift/hive) for custom resources and actual deploymen of certificates. It is therefore **not** a suitable "out-of-the-box" solution for Let's Encrypt certificate management. For this, we recommend using either [openshift-acme](https://github.com/tnozicka/openshift-acme) or [cert-manager](https://github.com/jetstack/cert-manager). Certman Operator is ideal for use cases when large number of OpenShift clusters have to be managed centrally.
+* As described above in dependencies, Certman Operator requires [Hive](https://github.com/openshift/hive) for custom resources and actual deployment of certificates. It is therefore **not** a suitable "out-of-the-box" solution for Let's Encrypt certificate management. For this, we recommend using either [openshift-acme](https://github.com/tnozicka/openshift-acme) or [cert-manager](https://github.com/jetstack/cert-manager). Certman Operator is ideal for use cases when a large number of OpenShift clusters have to be managed centrally.
 * Certman Operator currently only supports [DNS Challenges](https://tools.ietf.org/html/rfc8555#section-8.4) through AWS Route53. There are plans for GCP support. [HTTP Challenges](https://tools.ietf.org/html/rfc8555#section-8.3) is not supported.
-* Certman Operator does not support creation of Let's Encrypt account at this time. You must already have Let's Encrypt account and keys that you can provide to the Certman Operator.
+* Certman Operator does not support creation of Let's Encrypt accounts at this time. You must already have a Let's Encrypt account and keys that you can provide to the Certman Operator.
 * Certman Operator does NOT configure the TLS certificates in an OpenShift cluster. This is managed by [Hive](https://github.com/openshift/hive) using [SyncSet](https://github.com/openshift/hive/blob/master/docs/syncset.md).
 
 ## CustomResourceDefinitions
@@ -67,20 +92,16 @@ The script `hack/test/local_test.sh` can be used to automate local testing by cr
 
 ### Certman Operator Configuration
 
-A [ConfigMap](https://docs.openshift.com/container-platform/3.11/dev_guide/configmaps.html) is used to store certman operator configuration. At the moment, there are 2 items that can be configured using ConfigMap.
-
-1. `default_notification_email_address` - Email address to which Let's Encrypt certificate expiry notifications should be sent.
-2. `lets_encrypt_environment` - Which Let's Encrypt environment to use - can be `staging` or `production`.
+A [ConfigMap](https://docs.openshift.com/container-platform/3.11/dev_guide/configmaps.html) is used to store certman operator configuration. The ConfigMap contains one value, `default_notification_email_address`, the email address to which Let's Encrypt certificate expiry notifications should be sent.
 
 ```
 oc create configmap certman-operator \
     --from-literal=default_notification_email_address=foo@bar.com
-    --from-literal=lets_encrypt_environment=staging
 ```
 
 ### Certman Operator Secrets
 
-[Secret](https://kubernetes.io/docs/concepts/configuration/secret/) is used to store Let's Encrypt account url and keys. We will use Let's Encrypt staging environment if it's an staging account, and use production environment if it's an production account.
+A [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) is used to store the Let's Encrypt account url and keys.
 
 ```
  oc create secret generic lets-encrypt-account-staging \
@@ -109,7 +130,7 @@ oc create -f https://raw.githubusercontent.com/openshift/certman-operator/master
 ### Run Operator From Source
 
 ```
-operator-sdk up local
+operator-sdk run --local
 ```
 
 ### Build Operator Image
@@ -128,7 +149,6 @@ docker push quay.io/tparikh/certman-operator
 
 ```
 oc new-project certman-operator
-oc project certman-operator
 ```
 
 ####  Setup Service Account
@@ -145,6 +165,8 @@ oc create -f deploy/role_binding.yaml
 ```
 
 #### Deploy the Operator
+
+Edit [deploy/operator.yaml](deploy/operator.yaml), substituting the reference to the `image` you built above. Then deploy it:
 ```
 oc create -f deploy/operator.yaml
 ```

--- a/hack/test/configmap.yaml
+++ b/hack/test/configmap.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 data:
   default_notification_email_address: sedgar@redhat.com
-  lets_encrypt_environment: staging
 kind: ConfigMap
 metadata:
   annotations:

--- a/pkg/clients/types/types.go
+++ b/pkg/clients/types/types.go
@@ -4,5 +4,4 @@ const (
 	AcmeChallengeSubDomain          = "_acme-challenge"
 	WriteValidationSubDomain        = "_certman_access_test"
 	DefaultNotificationEmailAddress = "default_notification_email_address"
-	LetsEncryptEnvironment          = "lets_encrypt_environment"
 )

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -350,7 +350,6 @@ func testObjects() []runtime.Object {
 			Namespace: "certman-operator",
 		},
 		Data: map[string]string{
-			cTypes.LetsEncryptEnvironment:          "staging",
 			cTypes.DefaultNotificationEmailAddress: "email@example.com",
 		},
 	}


### PR DESCRIPTION
This adds a generated ToC, fixes some broken links, updates references
to older required versions of things, addresses some typographical
errors, and generally tidies things up.

Almost no meaning/content is changed.

While doing this, it was discovered that the `lets_encrypt_environment`
configmap key is unused, but had a vestigial presence in a const and
test as well as the README. These are cleaned up here.