### PR TITLE
Optimize CertificateRequest Reconcile Behavior

### DIFF
--- a/hack/test/scale-test.sh
+++ b/hack/test/scale-test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# This script will test certman-operator in minikube by doing the following:
+# 1. Spoof a ClusterDeployment to replicate running in Hive,
+#    which will trigger certificates to be generated.
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+BASE_DOMAIN=fidata.io
+
+TOTAL_COUNT=${1:-10}
+
+NAMES_ARR=()
+START_TIMES_ARR=()
+DURATION_TIMES_ARR=()
+
+function cleanup() {
+    for i in $(seq 1 $TOTAL_COUNT)
+    do
+        NAME=${NAMES_ARR[$i]}
+        kubectl delete clusterdeployment ${NAME}
+    done
+}
+
+trap cleanup INT TERM EXIT
+
+for i in $(seq 1 $TOTAL_COUNT)
+do
+    CD_START_TIME=`date +%s`
+    RAND0=$(head /dev/urandom | tr -dc a-z | head -c 4 ; echo '')
+    RAND2=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 8 ; echo '')
+
+    NAMES_ARR[$i]=${RAND0}
+    START_TIMES_ARR[$i]=${CD_START_TIME}
+
+    cat <<EOF | kubectl apply -f -
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  creationTimestamp: null
+  labels:
+    api.openshift.com/ccs: "false"
+    api.openshift.com/environment: staging
+    api.openshift.com/managed: "true"
+    api.openshift.com/name: ${RAND0}
+    api.openshift.com/service-lb-quota: "0"
+    api.openshift.com/storage-quota-gib: "100"
+    hive.openshift.io/cluster-platform: aws
+    hive.openshift.io/cluster-region: us-west-2
+    hive.openshift.io/cluster-type: managed
+  name: ${RAND0}
+spec:
+  baseDomain: ${BASE_DOMAIN}
+  certificateBundles:
+  - certificateSecretRef:
+      name: ${RAND0}-primary-cert-bundle-secret
+    generate: true
+    name: ${RAND0}-primary-cert-bundle
+  clusterMetadata:
+    adminKubeconfigSecretRef:
+      name: ${RAND0}-admin-kubeconfig
+    adminPasswordSecretRef:
+      name: ${RAND0}-admin-password
+    clusterID: ${RAND2}
+    infraID: ${RAND2}
+  clusterName: ${RAND0}
+  ingress:
+  - domain: ${RAND0}.${BASE_DOMAIN}
+    name: default
+    servingCertificate: ${RAND0}-primary-cert-bundle
+  installed: true
+  manageDNS: true
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: aws
+      region: us-west-2
+  provisioning:
+    imageSetRef:
+      name: openshift-v4.3.25
+    installConfigSecretRef:
+      name: install-config
+    sshPrivateKeySecretRef:
+      name: ssh
+  pullSecretRef:
+    name: pull
+EOF
+done
+
+ISSUED_COUNT=0
+
+echo "Waiting for $TOTAL_COUNT certificates to be issued..."
+
+while [ $ISSUED_COUNT -lt $TOTAL_COUNT ]
+do
+    for i in $(seq 1 $TOTAL_COUNT)
+    do
+        NAME=${NAMES_ARR[$i]}
+
+        if [ ! ${DURATION_TIMES_ARR[$i]+abc} ]; then
+            #echo "Checking if ${NAME}.${BASE_DOMAIN} certificate was issued"
+            ISSUED=$(kubectl get certificaterequests ${NAME}-${NAME}-primary-cert-bundle -o json | jq .status.issued)
+
+            if [ "${ISSUED}" == "true" ]; then
+                CERT_ISSUED_END_TIME=`date +%s`
+                CERT_ISSUE_DURATION=$((CERT_ISSUED_END_TIME-CD_START_TIME))
+                DURATION_TIMES_ARR[$i]=${CERT_ISSUE_DURATION}
+                echo "${NAME} ISSUE DURATION: ${CERT_ISSUE_DURATION} seconds"
+                ((ISSUED_COUNT++))
+            fi
+        fi
+    done
+    sleep 1
+done
+
+cleanup

--- a/pkg/controller/certificaterequest/cloudflare.go
+++ b/pkg/controller/certificaterequest/cloudflare.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 )
 
 type CloudflareQuestion struct {
@@ -108,8 +107,7 @@ func VerifyDnsResourceRecordUpdate(reqLogger logr.Logger, fqdn string, txtValue 
 		return 0
 	}
 
-	errMsg := fmt.Sprintf("unable to verify that resource record %v has been updated to value %v.", fqdn, txtValue)
-	reqLogger.Error(errors.New(errMsg), errMsg)
+	reqLogger.Info(fmt.Sprintf("unable to verify that resource record %v has been updated to value %v.", fqdn, txtValue))
 	return waitPeriod
 }
 

--- a/pkg/controller/certificaterequest/cloudflare_test.go
+++ b/pkg/controller/certificaterequest/cloudflare_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificaterequest
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	logrTesting "github.com/go-logr/logr/testing"
+)
+
+func TestVerifyDnsResourceRecordUpdate(t *testing.T) {
+	type args struct {
+		reqLogger logr.Logger
+		fqdn      string
+		txtValue  string
+	}
+	nullLogger := logrTesting.NullLogger{}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "Test Max Negative TTL",
+			args: args{
+				reqLogger: nullLogger,
+				fqdn:      "apps.foobar.com",
+				txtValue:  "foobar",
+			},
+			want: maxNegativeCacheTTL,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := VerifyDnsResourceRecordUpdate(tt.args.reqLogger, tt.args.fqdn, tt.args.txtValue); got != tt.want {
+				t.Errorf("VerifyDnsResourceRecordUpdate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchResourceRecordUsingCloudflareDNS(t *testing.T) {
+	type args struct {
+		reqLogger logr.Logger
+		name      string
+	}
+	nullLogger := logrTesting.NullLogger{}
+	tests := []struct {
+		name    string
+		args    args
+		want    *CloudflareResponse
+		wantErr bool
+	}{
+		{
+			name: "Test Response",
+			args: args{
+				reqLogger: nullLogger,
+				name:      "apps.foobar.com",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := FetchResourceRecordUsingCloudflareDNS(tt.args.reqLogger, tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FetchResourceRecordUsingCloudflareDNS() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/pkg/controller/certificaterequest/constants.go
+++ b/pkg/controller/certificaterequest/constants.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package certificaterequest
 
+import (
+	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
+)
+
 type dnsRCode int
 
 const (
@@ -39,5 +43,5 @@ const (
 	dnsRCodeRefused        dnsRCode = 5
 
 	// cr annotation dns check attempts label
-	dnsCheckAttemptsLabel = "dns-check-attempts"
+	dnsCheckAttemptsAnnotation = certmanv1alpha1.CertmanOperatorFinalizerLabel + "/dns-check-attempts"
 )

--- a/pkg/controller/certificaterequest/constants.go
+++ b/pkg/controller/certificaterequest/constants.go
@@ -19,15 +19,16 @@ package certificaterequest
 type dnsRCode int
 
 const (
-	cloudflareDNSOverHttpsEndpoint    = "https://cloudflare-dns.com/dns-query"
-	cloudflareRequestContentType      = "application/dns-json"
-	cloudflareRequestTimeout          = 60
-	maxAttemptsForDnsPropagationCheck = 10  // Try 10 times (5 minutes total)
-	waitTimePeriodDnsPropagationCheck = 30  // Wait 30 seconds between checks
-	maxNegativeCacheTTL               = 600 // Sleep no more than 10 minutes
-	reissueCertificateBeforeDays      = 45  // This helps us avoid getting email notifications from Let's Encrypt.
-	resourceRecordTTL                 = 60
-	rSAKeyBitSize                     = 2048
+	cloudflareDNSOverHTTPSEndpoint       = "https://cloudflare-dns.com/dns-query"
+	cloudflareRequestContentType         = "application/dns-json"
+	cloudflareRequestTimeout             = 60
+	maxAttemptsForDNSPropagationCheck    = 10  // Try 10 times (5 minutes total)
+	initialWaitPeriodDNSPropagationCheck = 60  // Initial 60 seconds wait period to prevent negative cache ttl response
+	defaultWaitPeriodDNSPropagationCheck = 30  // Wait 30 seconds between checks
+	maxNegativeCacheTTL                  = 600 // Sleep no more than 10 minutes
+	reissueCertificateBeforeDays         = 45  // This helps us avoid getting email notifications from Let's Encrypt.
+	resourceRecordTTL                    = 60
+	rSAKeyBitSize                        = 2048
 
 	// From golang.org/x/net/dns/dnsmessage
 	dnsRCodeSuccess        dnsRCode = 0
@@ -36,4 +37,7 @@ const (
 	dnsRCodeNameError      dnsRCode = 3
 	dnsRCodeNotImplemented dnsRCode = 4
 	dnsRCodeRefused        dnsRCode = 5
+
+	// cr annotation dns check attempts label
+	dnsCheckAttemptsLabel = "dns-check-attempts"
 )

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -125,12 +125,12 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 			return initialWaitPeriodDNSPropagationCheck, nil
 		}
 
-		sleepDuration := VerifyDnsResourceRecordUpdate(reqLogger, fqdn, DNS01KeyAuthorization)
-		if sleepDuration != 0 {
+		waitPeriod := VerifyDnsResourceRecordUpdate(reqLogger, fqdn, DNS01KeyAuthorization)
+		if waitPeriod != 0 {
 			if verifyAttempts >= maxAttemptsForDNSPropagationCheck {
-				return sleepDuration, fmt.Errorf("max attempts made, cannot complete Let's Encrypt challenege as DNS changes could not be verified")
+				return waitPeriod, fmt.Errorf("max attempts made, cannot complete Let's Encrypt challenege as DNS changes could not be verified")
 			}
-			return sleepDuration, nil
+			return waitPeriod, nil
 		}
 
 		reqLogger.Info(fmt.Sprintf("Updating challenge for authorization %v: %v", domain, leClient.GetChallengeURL()))

--- a/pkg/controller/certificaterequest/issue_certificate_test.go
+++ b/pkg/controller/certificaterequest/issue_certificate_test.go
@@ -32,10 +32,13 @@ func TestIssueCertificate(t *testing.T) {
 
 		nullLogger := logrTesting.NullLogger{}
 
-		err := rcr.IssueCertificate(nullLogger, certRequest, certSecret)
+		waitPeriod, err := rcr.IssueCertificate(nullLogger, certRequest, certSecret)
 
 		if err == nil {
 			t.Error("expected an error")
+		}
+		if waitPeriod != -1 {
+			t.Error("expected a wait period of -1")
 		}
 	})
 }

--- a/pkg/controller/certificaterequest/utils_test.go
+++ b/pkg/controller/certificaterequest/utils_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificaterequest
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	logrTesting "github.com/go-logr/logr/testing"
+	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
+	cClient "github.com/openshift/certman-operator/pkg/clients"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestReconcileCertificateRequest_IncrementDNSVerifyAttempts(t *testing.T) {
+	type fields struct {
+		client        client.Client
+		scheme        *runtime.Scheme
+		clientBuilder func(kubeClient client.Client, platfromSecret certmanv1alpha1.Platform, namespace string) (cClient.Client, error)
+	}
+	type args struct {
+		reqLogger logr.Logger
+		cr        *certmanv1alpha1.CertificateRequest
+	}
+	nullLogger := logrTesting.NullLogger{}
+	testClient := setUpEmptyTestClient(t)
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Has annotation",
+			fields: fields{
+				client: testClient,
+			},
+			args: args{
+				reqLogger: nullLogger,
+				cr: &certmanv1alpha1.CertificateRequest{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							certmanv1alpha1.CertmanOperatorFinalizerLabel + "/" + dnsCheckAttemptsLabel: "3",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileCertificateRequest{
+				client:        tt.fields.client,
+				scheme:        tt.fields.scheme,
+				clientBuilder: tt.fields.clientBuilder,
+			}
+			if err := r.IncrementDNSVerifyAttempts(tt.args.reqLogger, tt.args.cr); (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileCertificateRequest.IncrementDNSVerifyAttempts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetDNSVerifyAttempts(t *testing.T) {
+	type args struct {
+		cr *certmanv1alpha1.CertificateRequest
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "Missing Annotation",
+			args: args{
+				cr: &certmanv1alpha1.CertificateRequest{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "Correct Annotation",
+			args: args{
+				cr: &certmanv1alpha1.CertificateRequest{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							certmanv1alpha1.CertmanOperatorFinalizerLabel + "/" + dnsCheckAttemptsLabel: "7",
+						},
+					},
+				},
+			},
+			want: 7,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetDNSVerifyAttempts(tt.args.cr); got != tt.want {
+				t.Errorf("GetDNSVerifyAttempts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/certificaterequest/utils_test.go
+++ b/pkg/controller/certificaterequest/utils_test.go
@@ -44,6 +44,7 @@ func TestReconcileCertificateRequest_IncrementDNSVerifyAttempts(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
+		want    int
 		wantErr bool
 	}{
 		{
@@ -56,11 +57,12 @@ func TestReconcileCertificateRequest_IncrementDNSVerifyAttempts(t *testing.T) {
 				cr: &certmanv1alpha1.CertificateRequest{
 					ObjectMeta: v1.ObjectMeta{
 						Annotations: map[string]string{
-							certmanv1alpha1.CertmanOperatorFinalizerLabel + "/" + dnsCheckAttemptsLabel: "3",
+							dnsCheckAttemptsAnnotation: "3",
 						},
 					},
 				},
 			},
+			want:    4,
 			wantErr: false,
 		},
 	}
@@ -73,6 +75,9 @@ func TestReconcileCertificateRequest_IncrementDNSVerifyAttempts(t *testing.T) {
 			}
 			if err := r.IncrementDNSVerifyAttempts(tt.args.reqLogger, tt.args.cr); (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileCertificateRequest.IncrementDNSVerifyAttempts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got := GetDNSVerifyAttempts(tt.args.cr); got != tt.want {
+				t.Errorf("ReconcileCertificateRequest.IncrementDNSVerifyAttempts() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -106,7 +111,7 @@ func TestGetDNSVerifyAttempts(t *testing.T) {
 				cr: &certmanv1alpha1.CertificateRequest{
 					ObjectMeta: v1.ObjectMeta{
 						Annotations: map[string]string{
-							certmanv1alpha1.CertmanOperatorFinalizerLabel + "/" + dnsCheckAttemptsLabel: "7",
+							dnsCheckAttemptsAnnotation: "7",
 						},
 					},
 				},


### PR DESCRIPTION
These changes fix the reconcile behavior of the CertificateRequest reconcile to requeue after a certain duration such that subsequent CRs can be processed. The old behavior was effectively processing each CR in serial and this changes it to a rapid succession.