### PR TITLE
[OSD-5050] - Fixing the bad computation for certif issuance metric

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -143,10 +143,11 @@ func main() {
 
 	// Instantiate metricsServer object configured with variables defined in
 	// localmetrics package.
-	metricsServer := metrics.NewBuilder().WithPort(metricsPort).WithPath(metricsPath).
+	metricsServer := metrics.NewBuilder(operatorconfig.OperatorNamespace, operatorconfig.OperatorName).
+		WithPort(metricsPort).
+		WithPath(metricsPath).
 		WithCollectors(localmetrics.MetricsList).
 		WithRoute().
-		WithServiceName(operatorconfig.OperatorName).
 		GetConfig()
 
 	// Get the namespace the operator is currently deployed in.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/cluster-network-operator v0.0.0-20190207145423-c226dcab667e // indirect
 	github.com/openshift/hive v1.0.0
-	github.com/openshift/operator-custom-metrics v0.3.0
+	github.com/openshift/operator-custom-metrics v0.3.1-0.20200901174648-463079905232
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.2.1

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -19,9 +19,9 @@ package certificaterequest
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,11 +111,10 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 
 	reqLogger.Info("reconciling CertificateRequest")
 
-	start := time.Now()
+	timer := prometheus.NewTimer(localmetrics.MetricCertificateRequestReconcileDuration)
 	defer func() {
-		reconcileDuration := time.Since(start).Seconds()
+		reconcileDuration := timer.ObserveDuration()
 		reqLogger.WithValues("Duration", reconcileDuration).Info("Reconcile complete.")
-		localmetrics.ObserveCertificateRequestReconcile(reconcileDuration)
 	}()
 
 	// Fetch the CertificateRequest cr

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -38,7 +38,8 @@ import (
 // form of resource record. Certificates are then generated and issued to kubernetes via corev1.
 func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest, certificateSecret *corev1.Secret) error {
 	timer := prometheus.NewTimer(localmetrics.MetricIssueCertificateDuration)
-	defer localmetrics.UpdateCertificateIssueDurationMetric(timer.ObserveDuration())
+	
+	defer timer.ObserveDuration()
 
 	// Get DNS client from CR.
 	dnsClient, err := r.getClient(cr)

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,11 +108,10 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("reconciling ClusterDeployment")
 
-	start := time.Now()
+	timer := prometheus.NewTimer(localmetrics.MetricClusterDeploymentReconcileDuration)
 	defer func() {
-		reconcileDuration := time.Since(start).Seconds()
+		reconcileDuration := timer.ObserveDuration()
 		reqLogger.WithValues("Duration", reconcileDuration).Info("Reconcile complete.")
-		localmetrics.ObserveClusterDeploymentReconcile(reconcileDuration)
 	}()
 
 	// Fetch the ClusterDeployment instance

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -99,17 +99,3 @@ func UpdateMetrics(hour int) {
 		UpdateCertsIssuedInLastWeekGauge()
 	}
 }
-
-func UpdateCertificateIssueDurationMetric(time time.Duration) {
-	MetricIssueCertificateDuration.Observe(float64(time.Seconds()))
-}
-
-// ObserveCertificateRequestReconcile records the duration of the reconcile loop of the operator
-func ObserveCertificateRequestReconcile(seconds float64) {
-	MetricCertificateRequestReconcileDuration.Observe(seconds)
-}
-
-// ObserveClusterDeploymentReconcile records the duration of the reconcile loop of the operator
-func ObserveClusterDeploymentReconcile(seconds float64) {
-	MetricClusterDeploymentReconcileDuration.Observe(seconds)
-}


### PR DESCRIPTION
2 things being fixed here : 
- calling ObserveDuration on a prometheus timer is already pushing the data, so shouldn't callObserve method on top of it as duplicating the data point
- having ObserveDuration as a in-parameter of a function, its evaluation is not defered which lead to reported time to be wrong

In addition, updating to more recent of `operator-custom-metrics` due to broken dependencies on v0.3.0 (using the same than on pagerduty-operator)