### PR TITLE
Add certificate issuance rate

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -182,6 +182,7 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 			return reconcile.Result{}, err
 		}
 
+		localmetrics.AddCertificateIssuance("renewal")
 		err = r.client.Update(context.TODO(), found)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -265,6 +266,7 @@ func (r *ReconcileCertificateRequest) createCertificateSecret(reqLogger logr.Log
 	}
 
 	reqLogger.Info("creating secret with certificates")
+	localmetrics.AddCertificateIssuance("create")
 
 	err = r.client.Create(context.TODO(), certificateSecret)
 	if err != nil {

--- a/pkg/controller/certificaterequest/issue_certificate.go
+++ b/pkg/controller/certificaterequest/issue_certificate.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -57,6 +58,7 @@ func (r *ReconcileCertificateRequest) IssueCertificate(reqLogger logr.Logger, cr
 	if proceed {
 		reqLogger.Info("write permissions for DNS has been validated")
 	} else {
+		err = errors.New("failed to get write access to DNS record")
 		reqLogger.Error(err, "failed to get write access to DNS record")
 		return err
 	}

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -66,6 +66,10 @@ var (
 		Help: "Report the current count of Certificate Requests",
 		ConstLabels: prometheus.Labels{"name": "certman-operator"},
 	})
+	MetricCertIssuanceRate = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "certman_operator_issued_certficates_count",
+		Help: "Counter on the number of issued certificate",
+	}, []string{"name", "action"})
 
 	MetricsList = []prometheus.Collector{
 		MetricCertsIssuedInLastDayDevshiftOrg,
@@ -77,6 +81,7 @@ var (
 		MetricCertificateRequestReconcileDuration,
 		MetricClusterDeploymentReconcileDuration,
 		MetricCertRequestsCount,
+		MetricCertIssuanceRate,
 	}
 	
 	areCountInitialized = false
@@ -147,4 +152,9 @@ func IncrementCertRequestsCounter() {
 // DecrementCertRequestsCounter Decrement the count of certificate requests
 func DecrementCertRequestsCounter() {
 	MetricCertRequestsCount.Dec()
+}
+
+// AddCertificateIssuance Increment the count of issued certificate
+func AddCertificateIssuance(action string) {
+	MetricCertIssuanceRate.With(prometheus.Labels{"name": "certman-operator", "action": action}).Inc()
 }


### PR DESCRIPTION
This PR is adding a counter on the number of issued certificate.
In addition, it is adding missing error in 1 scenario detected while testing the code (in case we can't get write access to DNS record, we were forwarding a nil error instead of an actual one, leading secret to be created while no certificate).

This PR is based on code from PR161 - Adding new counter for CertificateRequest (as touching the same pieces of code) and should only be merged after this one to have a clear change history so setting this PR as WIP for now. 