### PR TITLE
OSD-6070 patch clusterdeployment instead of update

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -145,8 +145,9 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 	if !utils.ContainsString(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel) {
 		reqLogger.Info("adding finalizer to the certificate request")
 		localmetrics.IncrementCertRequestsCounter()
+		baseToPatch := client.MergeFrom(cr.DeepCopy())
 		cr.ObjectMeta.Finalizers = append(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel)
-		if err := r.client.Update(context.TODO(), cr); err != nil {
+		if err := r.client.Patch(context.TODO(), cr, baseToPatch); err != nil {
 			reqLogger.Error(err, err.Error())
 			return reconcile.Result{}, err
 		}
@@ -233,8 +234,9 @@ func (r *ReconcileCertificateRequest) finalizeCertificateRequest(reqLogger logr.
 		}
 
 		reqLogger.Info("removing finalizers")
+		baseToPatch := client.MergeFrom(cr.DeepCopy())
 		cr.ObjectMeta.Finalizers = utils.RemoveString(cr.ObjectMeta.Finalizers, certmanv1alpha1.CertmanOperatorFinalizerLabel)
-		if err := r.client.Update(context.TODO(), cr); err != nil {
+		if err := r.client.Patch(context.TODO(), cr, baseToPatch); err != nil {
 			reqLogger.Error(err, err.Error())
 			return reconcile.Result{}, err
 		}


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
This PR changes the logic of the `certman-operator` to perform a `Patch()` of the `clusterdeployment` CR when adding or removing finalizers, rather than an `Update()`, in order to eliminate the possibility that the `Update()` call will drop data from the CR.

### Which Jira/Github issue(s) this PR fixes?
[OSD-6070](https://issues.redhat.com/browse/OSD-6070)

### Special notes for your reviewer:
I've tested this with a local deployment of `certman-operator` and verified that finalizers are still created and removed as expected. I have also verified that - if the Hive `clusterdeployment` CRD introduces a new field and sets that value in a `clusterdeployment` CR - the currently running operator does not remove that new field when it performs the `Patch()`, as per the goals of [OSD-6070](https://issues.redhat.com/browse/OSD-6070).

Related PRs:
- [pagerduty-operator](https://github.com/openshift/pagerduty-operator/pull/137)
- [deadmanssnitch-operator](https://github.com/openshift/deadmanssnitch-operator/pull/99)

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
