### PR TITLE
Cluster migration no cleanup

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -147,6 +147,7 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 	// Do not reconcile if the cluster is being relocated
 	for a, v := range cd.Annotations {
 		if a == hiveRelocationAnnotation && strings.Split(v, "/")[1] == hiveRelocationOutgoingValue {
+			reqLogger.Info("Not reconciling: ClusterDeployment %s is relocating", cd.Name)
 			return reconcile.Result{}, nil
 		}
 	}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -50,6 +50,8 @@ var log = logf.Log.WithName("controller_clusterdeployment")
 const (
 	controllerName                = "clusterdeployment"
 	ClusterDeploymentManagedLabel = "api.openshift.com/managed"
+	hiveRelocationAnnotation      = "hive.openshift.io/relocate"
+	hiveRelocationOutgoingValue   = "outgoing"
 )
 
 // Add creates a new ClusterDeployment Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -140,6 +142,13 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 	if !cd.Spec.Installed {
 		reqLogger.Info(fmt.Sprintf("cluster %v is not yet in installed state", cd.Name))
 		return reconcile.Result{}, nil
+	}
+
+	// Do not reconcile if the cluster is being relocated
+	for a, v := range cd.Annotations {
+		if a == hiveRelocationAnnotation && strings.Split(v, "/")[1] == hiveRelocationOutgoingValue {
+			return reconcile.Result{}, nil
+		}
 	}
 
 	// Check if CertificateResource is being deleted, if it's deleted remove the finalizer if it exists.

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -153,6 +153,16 @@ func TestReconcileClusterDeployment(t *testing.T) {
 			}(),
 			expectFinalizerPresent: true,
 		},
+		{
+			name: "Test cluster relocation",
+			localObjects: func() []runtime.Object {
+				cd := testClusterDeploymentAws()
+				cd.SetAnnotations(map[string]string{"hive.openshift.io/relocate": "fakehive/outgoing"})
+				return []runtime.Object{cd}
+			}(),
+			// if the finalizer isn't present and no errors bubble up, the reconcile loop didn't run
+			expectFinalizerPresent: false,
+		},
 	}
 
 	// Iterate over test array.

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -80,24 +80,24 @@ func TestReconcileClusterDeployment(t *testing.T) {
 		expectFinalizerPresent      bool
 	}{
 		{
-			name:         "Test no cert bundles to generate",
-			localObjects: testObjects(testClusterDeploymentAws()),
+			name:                   "Test no cert bundles to generate",
+			localObjects:           testObjects(testClusterDeploymentAws()),
 			expectFinalizerPresent: true,
 		},
 		{
 
-			name:         "Test un-managed certificate request",
-			localObjects: testObjects(testUnmanagedClusterDeployment()),
+			name:                   "Test un-managed certificate request",
+			localObjects:           testObjects(testUnmanagedClusterDeployment()),
 			expectFinalizerPresent: false,
 		},
 		{
-			name:         "Test not installed cluster deployment",
-			localObjects: testObjects(testNotInstalledClusterDeployment()),
+			name:                   "Test not installed cluster deployment",
+			localObjects:           testObjects(testNotInstalledClusterDeployment()),
 			expectFinalizerPresent: false,
 		},
 		{
-			name:         "Test deletion of certificate request",
-			localObjects: testObjects(testhandleDeleteClusterDeployment()),
+			name:                   "Test deletion of certificate request",
+			localObjects:           testObjects(testhandleDeleteClusterDeployment()),
 			expectFinalizerPresent: false,
 		},
 


### PR DESCRIPTION
if a cluster is being migrated between hive instances, we don't want to reconcile the clusterdeployment