### PR TITLE
Add STS support for route53 client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-openapi/spec v0.20.3
 	github.com/lib/pq v1.2.0
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
-	github.com/openshift/aws-account-operator/apis v0.0.0-20210415194408-b26c2338cf07
+	github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210521135120-4790241bcdd5
 	github.com/openshift/hive v1.0.16-0.20201211144432-f97557354336
 	github.com/openshift/operator-custom-metrics v0.3.1-0.20200901174648-463079905232
 	github.com/operator-framework/operator-sdk v0.17.2

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,10 @@ require (
 	github.com/aws/aws-sdk-go v1.34.19
 	github.com/eggsampler/acme v1.0.0
 	github.com/go-logr/logr v0.2.1
-	github.com/go-openapi/spec v0.19.4
+	github.com/go-openapi/spec v0.20.3
 	github.com/lib/pq v1.2.0
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
+	github.com/openshift/aws-account-operator/apis v0.0.0-20210415194408-b26c2338cf07
 	github.com/openshift/hive v1.0.16-0.20201211144432-f97557354336
 	github.com/openshift/operator-custom-metrics v0.3.1-0.20200901174648-463079905232
 	github.com/operator-framework/operator-sdk v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -1217,8 +1217,11 @@ github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mo
 github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible h1:AvJ2SgJ7ekSlEL/wyeVMffxDkbKohp4JLge9wMtT23o=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
-github.com/openshift/aws-account-operator/apis v0.0.0-20210415194408-b26c2338cf07 h1:XjoKfy6F7TIhdhj8qB/KWNvCqteHD5ULhQ6QeV004U8=
-github.com/openshift/aws-account-operator/apis v0.0.0-20210415194408-b26c2338cf07/go.mod h1:4q5N6qtEAH7fBi2nHVKn8uGLl9ifLz3JAsbVlccljwY=
+github.com/openshift/aws-account-operator v0.0.0-20210521135120-4790241bcdd5 h1:F9zDW7I2BxnRxITwJGTwnFbPtfXojDOFNv50I3Ec1Y0=
+github.com/openshift/aws-account-operator/apis v0.0.0-20210419151353-80393aedb995 h1:eaIUUrqLxg24FVsCaEZCqmG85TOVia0XX6Yaz3YMrug=
+github.com/openshift/aws-account-operator/apis v0.0.0-20210419151353-80393aedb995/go.mod h1:4q5N6qtEAH7fBi2nHVKn8uGLl9ifLz3JAsbVlccljwY=
+github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210521135120-4790241bcdd5 h1:OAyuDn7ZLLpWw3xxcOe9tvFbf/mPycZjMDgvGOt9+Lc=
+github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210521135120-4790241bcdd5/go.mod h1:cLnYI1elYBw8yiSJMkJtYP7CWnG8N3yB26XM3SnDYtA=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=

--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,8 @@ github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwds
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
+github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
+github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.17.2/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
@@ -492,6 +494,8 @@ github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3Hfo
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
 github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
+github.com/go-openapi/jsonreference v0.19.5 h1:1WJP/wi4OjB4iV8KVbH73rQaoialJrqv8gitZLxGLtM=
+github.com/go-openapi/jsonreference v0.19.5/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE69AqPYEJeo/TWfEeg=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.17.2/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
@@ -511,6 +515,8 @@ github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcs
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/spec v0.19.4 h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=
 github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
+github.com/go-openapi/spec v0.20.3 h1:uH9RQ6vdyPSs2pSy9fL8QPspDF2AMIMPtmK5coSSjtQ=
+github.com/go-openapi/spec v0.20.3/go.mod h1:gG4F8wdEDN+YPBMVnzE85Rbhf+Th2DTvA9nFPQ5AYEg=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.17.2/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
@@ -525,6 +531,8 @@ github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.4/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
+github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/validate v0.17.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.17.2/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
@@ -946,6 +954,8 @@ github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52Cu
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joyent/triton-go v0.0.0-20180313100802-d8f9c0314926/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/joyent/triton-go v0.0.0-20190112182421-51ffac552869/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -1038,6 +1048,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
+github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/maorfr/helm-plugin-utils v0.0.0-20200216074820-36d2fcf6ae86/go.mod h1:p3gwmRSFqbWw6plBpR0sKl3n3vpu8kX70gvCJKMvvCA=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
@@ -1205,6 +1217,8 @@ github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mo
 github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible h1:AvJ2SgJ7ekSlEL/wyeVMffxDkbKohp4JLge9wMtT23o=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/aws-account-operator/apis v0.0.0-20210415194408-b26c2338cf07 h1:XjoKfy6F7TIhdhj8qB/KWNvCqteHD5ULhQ6QeV004U8=
+github.com/openshift/aws-account-operator/apis v0.0.0-20210415194408-b26c2338cf07/go.mod h1:4q5N6qtEAH7fBi2nHVKn8uGLl9ifLz3JAsbVlccljwY=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
@@ -1775,6 +1789,8 @@ golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
+golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1879,6 +1895,9 @@ golang.org/x/sys v0.0.0-20200509044756-6aff5f38e54f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1890,6 +1909,8 @@ golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5f
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
+golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -2160,10 +2181,14 @@ gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
@@ -2310,6 +2335,7 @@ k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH
 k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
+k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=

--- a/pkg/clients/aws/route53.go
+++ b/pkg/clients/aws/route53.go
@@ -24,27 +24,32 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	aaov1alpha1 "github.com/openshift/aws-account-operator/apis/aws/v1alpha1"
 	certmanv1alpha1 "github.com/openshift/certman-operator/pkg/apis/certman/v1alpha1"
 	cTypes "github.com/openshift/certman-operator/pkg/clients/types"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 )
 
 const (
-	awsCredsSecretIDKey        = "aws_access_key_id"
-	awsCredsSecretAccessKey    = "aws_secret_access_key"
-	resourceRecordTTL          = 60
-	clientMaxRetries           = 25
-	retryerMaxRetries          = 10
-	retryerMinThrottleDelaySec = 1
+	awsCredsSecretIDKey         = "aws_access_key_id"
+	awsCredsSecretAccessKey     = "aws_secret_access_key"
+	awsAccountOperatorNamespace = "aws-account-operator"
+	resourceRecordTTL           = 60
+	clientMaxRetries            = 25
+	retryerMaxRetries           = 10
+	retryerMinThrottleDelaySec  = 1
 )
 
 // awsClient implements the Client interface
@@ -280,7 +285,7 @@ func (c *awsClient) DeleteAcmeChallengeResourceRecords(reqLogger logr.Logger, cr
 // AWS credentials are returned as these secrets and a new session is initiated prior to returning
 // a client. If secrets fail to return, the IAM role of the masters is used to create a
 // new session for the client.
-func NewClient(kubeClient client.Client, secretName, namespace, region string) (*awsClient, error) {
+func NewClient(kubeClient client.Client, secretName, namespace, region, clusterDeploymentName string) (*awsClient, error) {
 	awsConfig := &aws.Config{
 		Region: aws.String(region),
 		// MaxRetries to limit the number of attempts on failed API calls
@@ -293,6 +298,121 @@ func NewClient(kubeClient client.Client, secretName, namespace, region string) (
 			MinThrottleDelay: retryerMinThrottleDelaySec * time.Second,
 		},
 	}
+
+	// Check if ClusterDeployment is labelled for STS
+	clusterDeployment := &hivev1.ClusterDeployment{}
+	err := kubeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      clusterDeploymentName,
+		Namespace: namespace,
+	}, clusterDeployment)
+	if err != nil {
+		return nil, err
+	}
+	if stsEnabled, ok := clusterDeployment.Labels["api.openshift.com/sts"]; ok && stsEnabled == "true" {
+		// Get STS jump role from from aws-account-operator ConfigMap
+		cm := &corev1.ConfigMap{}
+		err := kubeClient.Get(context.TODO(), types.NamespacedName{
+			Name:      aaov1alpha1.DefaultConfigMap,
+			Namespace: aaov1alpha1.AccountCrNamespace,
+		}, cm)
+
+		if err != nil {
+			fmt.Errorf("Error getting aws-account-operator ConfigMap to get the STS Jump Role: %v", err)
+			return nil, err
+		}
+
+		stsAccessARN := cm.Data["sts-jump-role"]
+		if stsAccessARN == "" {
+			fmt.Errorf("aws-account-operator configmap missing sts-jump-role: %v", aaov1alpha1.ErrInvalidConfigMap)
+			return nil, err
+		}
+
+		// Get STS Creds
+
+		s, err := session.NewSession(awsConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		hiveAwsClient := sts.New(s)
+
+		jumpRoleCreds, err := getSTSCredentials(hiveAwsClient, stsAccessARN, "", "certmanOperator")
+		if err != nil {
+			return nil, err
+		}
+
+		jumpConfig := &aws.Config{
+			Region:     aws.String(region),
+			MaxRetries: aws.Int(clientMaxRetries),
+			Retryer: awsclient.DefaultRetryer{
+				NumMaxRetries:    retryerMaxRetries,
+				MinThrottleDelay: retryerMinThrottleDelaySec * time.Second,
+			},
+			Credentials: credentials.NewStaticCredentials(
+				*jumpRoleCreds.Credentials.AccessKeyId,
+				*jumpRoleCreds.Credentials.SecretAccessKey,
+				*jumpRoleCreds.Credentials.SessionToken,
+			),
+		}
+
+		js, err := session.NewSession(jumpConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		jumpRoleClient := sts.New(js)
+
+		// Get Account's STS role from AccountClaim
+		accountClaim := &aaov1alpha1.AccountClaim{}
+		err = kubeClient.Get(context.TODO(), types.NamespacedName{
+			Name:      clusterDeploymentName,
+			Namespace: namespace,
+		}, accountClaim)
+		if err != nil {
+			return nil, err
+		}
+
+		if accountClaim.Spec.ManualSTSMode {
+			if accountClaim.Spec.STSRoleARN == "" {
+				return nil, fmt.Errorf("STSRoleARN missing from AccountClaim %v", accountClaim.Name)
+			}
+
+		}
+
+		// TODO: use the accountClaim.Spec.STSExternalID here once I move to the new aws-account-operator api
+		customerAccountCreds, err := getSTSCredentials(jumpRoleClient, accountClaim.Spec.STSRoleARN, "", "RH-Account-Initilization")
+
+		if err != nil {
+			return nil, err
+		}
+
+		customerAccountConfig := &aws.Config{
+			Region:     aws.String(region),
+			MaxRetries: aws.Int(clientMaxRetries),
+			Retryer: awsclient.DefaultRetryer{
+				NumMaxRetries:    retryerMaxRetries,
+				MinThrottleDelay: retryerMinThrottleDelaySec * time.Second,
+			},
+			Credentials: credentials.NewStaticCredentials(
+				*customerAccountCreds.Credentials.AccessKeyId,
+				*customerAccountCreds.Credentials.SecretAccessKey,
+				*customerAccountCreds.Credentials.SessionToken,
+			),
+		}
+
+		cs, err := session.NewSession(customerAccountConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		c := &awsClient{
+			client: route53.New(cs),
+		}
+
+		return c, err
+
+	}
+
 	if secretName != "" {
 		secret := &corev1.Secret{}
 		err := kubeClient.Get(context.TODO(),
@@ -336,4 +456,45 @@ func NewClient(kubeClient client.Client, secretName, namespace, region string) (
 	}
 
 	return c, err
+}
+
+func getSTSCredentials(client *sts.STS, roleArn string, externalID string, roleSessionName string) (*sts.AssumeRoleOutput, error) {
+	// Default duration in seconds of the session token 3600. We need to have the roles policy
+	// changed if we want it to be longer than 3600 seconds
+	var roleSessionDuration int64 = 3600
+	fmt.Printf("Creating STS credentials for AWS ARN: %s", roleArn)
+	// Build input for AssumeRole
+	assumeRoleInput := sts.AssumeRoleInput{
+		DurationSeconds: &roleSessionDuration,
+		RoleArn:         &roleArn,
+		RoleSessionName: &roleSessionName,
+	}
+	if externalID != "" {
+		assumeRoleInput.ExternalId = &externalID
+	}
+
+	assumeRoleOutput := &sts.AssumeRoleOutput{}
+	var err error
+	for i := 0; i < 100; i++ {
+		time.Sleep(500 * time.Millisecond)
+		assumeRoleOutput, err = client.AssumeRole(&assumeRoleInput)
+		if err == nil {
+			break
+		}
+		if i == 99 {
+			fmt.Printf("Timed out while assuming role %s", roleArn)
+		}
+	}
+	if err != nil {
+		// Log AWS error
+		if aerr, ok := err.(awserr.Error); ok {
+			fmt.Errorf(`New AWS Error while getting STS credentials,
+					AWS Error Code: %s,
+					AWS Error Message: %s`,
+				aerr.Code(),
+				aerr.Message())
+		}
+		return &sts.AssumeRoleOutput{}, err
+	}
+	return assumeRoleOutput, nil
 }

--- a/pkg/clients/client.go
+++ b/pkg/clients/client.go
@@ -23,11 +23,11 @@ type Client interface {
 }
 
 // NewClient returns an individual cloud implementation based on CertificateRequest cloud coniguration
-func NewClient(kubeClient client.Client, platform certmanv1alpha1.Platform, namespace string) (Client, error) {
+func NewClient(kubeClient client.Client, platform certmanv1alpha1.Platform, namespace string, clusterDeploymentName string) (Client, error) {
 	// TODO: Add multicloud checking here
 	if platform.AWS != nil {
 		log.Info("build aws client")
-		return aws.NewClient(kubeClient, platform.AWS.Credentials.Name, namespace, platform.AWS.Region)
+		return aws.NewClient(kubeClient, platform.AWS.Credentials.Name, namespace, platform.AWS.Region, clusterDeploymentName)
 	}
 	if platform.GCP != nil {
 		log.Info("build gcp client")

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -108,7 +108,7 @@ var _ reconcile.Reconciler = &ReconcileCertificateRequest{}
 type ReconcileCertificateRequest struct {
 	client        client.Client
 	scheme        *runtime.Scheme
-	clientBuilder func(kubeClient client.Client, platfromSecret certmanv1alpha1.Platform, namespace string) (cClient.Client, error)
+	clientBuilder func(kubeClient client.Client, platfromSecret certmanv1alpha1.Platform, namespace string, clusterDeploymentName string) (cClient.Client, error)
 }
 
 // Reconcile reads that state of the cluster for a CertificateRequest object and makes changes based on the state read
@@ -278,7 +278,13 @@ func newSecret(cr *certmanv1alpha1.CertificateRequest) *corev1.Secret {
 
 // getClient returns cloud specific client to the caller
 func (r *ReconcileCertificateRequest) getClient(cr *certmanv1alpha1.CertificateRequest) (cClient.Client, error) {
-	client, err := r.clientBuilder(r.client, cr.Spec.Platform, cr.Namespace)
+	clusterDeploymentName := ""
+	for _, ownerRef := range cr.OwnerReferences {
+		if ownerRef.Kind == "ClusterDeployment" {
+			clusterDeploymentName = ownerRef.Name
+		}
+	}
+	client, err := r.clientBuilder(r.client, cr.Spec.Platform, cr.Namespace, clusterDeploymentName)
 	return client, err
 }
 

--- a/pkg/controller/certificaterequest/test_helpers.go
+++ b/pkg/controller/certificaterequest/test_helpers.go
@@ -232,7 +232,7 @@ func (f FakeAWSClient) ValidateDNSWriteAccess(reqLogger logr.Logger, cr *certman
 }
 
 // Return an empty AWS client.
-func setUpFakeAWSClient(kubeClient client.Client, platfromSecret certmanv1alpha1.Platform, namespace string) (cClient.Client, error) {
+func setUpFakeAWSClient(kubeClient client.Client, platfromSecret certmanv1alpha1.Platform, namespace string, clusterDeplymentName string) (cClient.Client, error) {
 	return FakeAWSClient{}, nil
 }
 


### PR DESCRIPTION
This adds STS support for the route53 AWS client used by certman. When creating a route53 client will now check the clusterDeployment for a label indicating it is configured for STS. If the label is present, STS credentials will be returned to access route53 in the customer cluster.

This first pass is rough and the route53 client needs some refactoring in order to DRY out some of the repeated code in the NewClient function. I can start working on refactoring and cleaning up once we have a working implementation of this. 