### PR TITLE
Add RBAC for Get/List of AAO AccountClaims

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -64,5 +64,11 @@ rules:
   - routes
   verbs:
   - '*'
-
-
+- apiGroups:
+  - aws.managed.openshift.io
+  resources:
+  - accountclaims
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This PR adds RBAC to allow the certman ServiceAccount to Get and List aws-account-operator AccountClaim resrouces.