### PR TITLE
OSD-8263 recover a missing OwnerReference for a CertificateRequest

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -18,6 +18,7 @@ package certificaterequest
 
 import (
 	"context"
+	gerrors "errors"
 	"fmt"
 	"strings"
 
@@ -145,6 +146,11 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 	// assume there's only one clusterdeployment in a namespace and that it's the owner of this certificaterequest
 	// we have to assume this so that if/when a CertificateRequest loses its OwnerReferences, it can still reconcile
 	clusterDeploymentName := strings.Split(request.NamespacedName.Name, certRequestSuffix)[0]
+	if clusterDeploymentName == "" {
+		err = gerrors.New("ClusterDeployment not found")
+		reqLogger.Error(err, "ClusterDeployment not found")
+		return reconcile.Result{}, err
+	}
 	cd := &hivev1.ClusterDeployment{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: request.Namespace, Name: clusterDeploymentName}, cd)
 	if err != nil {

--- a/pkg/controller/certificaterequest/test_helpers.go
+++ b/pkg/controller/certificaterequest/test_helpers.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -39,6 +40,7 @@ import (
 
 var testHiveNamespace = "uhc-doesntexist-123456"
 var testHiveClusterDeploymentName = "clustername-1313"
+var testHiveClusterDeploymentUID = types.UID("some-fake-uid")
 var testHiveCertificateRequestName = fmt.Sprintf("%s-primary-cert-bundle", testHiveClusterDeploymentName)
 var testHiveSecretName = "primary-cert-bundle-secret"
 var testHiveACMEDomain = "not.a.valid.tld"
@@ -67,6 +69,7 @@ var clusterDeploymentComplete = &hivev1.ClusterDeployment{
 		Annotations: map[string]string{
 			"hive.openshift.io/relocate": "newhive/complete",
 		},
+		UID: testHiveClusterDeploymentUID,
 	},
 }
 var clusterDeploymentOutgoing = &hivev1.ClusterDeployment{
@@ -93,9 +96,12 @@ var certRequest = &certmanv1alpha1.CertificateRequest{
 		Name:      testHiveCertificateRequestName,
 		OwnerReferences: []metav1.OwnerReference{
 			{
-				APIVersion: "hive.openshift.io/v1",
-				Kind:       "ClusterDeployment",
-				Name:       testHiveClusterDeploymentName,
+				APIVersion:         "hive.openshift.io/v1",
+				Kind:               "ClusterDeployment",
+				Name:               testHiveClusterDeploymentName,
+				UID:                clusterDeploymentComplete.UID,
+				Controller:         boolPointer(true),
+				BlockOwnerDeletion: boolPointer(true),
 			},
 		},
 	},

--- a/pkg/controller/certificaterequest/utils.go
+++ b/pkg/controller/certificaterequest/utils.go
@@ -46,3 +46,8 @@ func GetSecret(kubeClient client.Client, secretName, namespace string) (*corev1.
 
 	return s, nil
 }
+
+// returns a pointer to a boolean
+func boolPointer(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
this assumes that:
* there will be exactly 1 ClusterDeployment per namespace that the
  CertificateRequest is in
* the CertificateRequest request is named
  <ClusterDeployment.Name>--primary-cert-bundle