### PR TITLE
Fixed a bug with `certman_operator_certificate_valid_duration_days`

### DIFF
--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -168,7 +168,7 @@ func AddCertificateIssuance(action string) {
 
 // UpdateCertValidDuration set the gauge to the number of remaining valid days for the cert
 func UpdateCertValidDuration(cert *x509.Certificate) {
-	diff := cert.NotAfter.Sub(time.Now())
+	diff := time.Until(cert.NotAfter)
 	days := diff.Hours() / 24
 	MetricCertValidDuration.With(prometheus.Labels{"cn": cert.Subject.CommonName}).Set(days)
 }

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -168,6 +168,7 @@ func AddCertificateIssuance(action string) {
 
 // UpdateCertValidDuration set the gauge to the number of remaining valid days for the cert
 func UpdateCertValidDuration(cert *x509.Certificate) {
-	now := time.Now()
-	MetricCertValidDuration.With(prometheus.Labels{"cn": cert.Subject.CommonName}).Set(float64(cert.NotAfter.YearDay() - now.YearDay()))
+	diff := cert.NotAfter.Sub(time.Now())
+	days := diff.Hours() / 24
+	MetricCertValidDuration.With(prometheus.Labels{"cn": cert.Subject.CommonName}).Set(days)
 }


### PR DESCRIPTION
Fixed the bug where UpdateCertValidDuration returns the wrong results if
the two dates are in different years