### PR TITLE
[OSD-8748] Update route53 client to support fedramp DNS01 challenges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.17.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
-	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.10.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -126,7 +126,7 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 	if len(os.Getenv(fedrampEnvVariable)) == 0 {
 		reqLogger.Info("FEDRAMP environment variable unset, defaulting to false")
 	} else {
-		reqLogger.Info("running in FedRAMP environment: %b", fedramp)
+		reqLogger.Info(fmt.Sprintf("running in FedRAMP environment: %t", fedramp))
 	}
 
 	if fedramp {
@@ -134,7 +134,7 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 			reqLogger.Info("HOSTED_ZONE_ID environment variable is unset but is required in FedRAMP environment")
 			return reconcile.Result{}, nil
 		}
-		reqLogger.Info("running in FedRAMP zone: %s", fedrampHostedZoneID)
+		reqLogger.Info(fmt.Sprintf("running in FedRAMP zone: %s", fedrampHostedZoneID))
 	}
 
 	timer := prometheus.NewTimer(localmetrics.MetricCertificateRequestReconcileDuration)

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -123,15 +123,18 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	reqLogger.Info("reconciling CertificateRequest")
-	if len(os.Getenv(fedrampEnvVariable)) == 0 {
+	envvar, present := os.LookupEnv(fedrampEnvVariable)
+	if len(envvar) == 0 || !present {
 		reqLogger.Info("FEDRAMP environment variable unset, defaulting to false")
 	} else {
 		reqLogger.Info(fmt.Sprintf("running in FedRAMP environment: %t", fedramp))
 	}
 
 	if fedramp {
-		if len(os.Getenv(fedrampHostedZoneIDVariable)) == 0 {
-			reqLogger.Info("HOSTED_ZONE_ID environment variable is unset but is required in FedRAMP environment")
+		envvar, present = os.LookupEnv(fedrampHostedZoneIDVariable)
+		if len(envvar) == 0 || !present {
+			err := gerrors.New("HOSTED_ZONE_ID environment variable is unset but is required in FedRAMP environment")
+			reqLogger.Error(err, "HOSTED_ZONE_ID environment variable is unset but is required in FedRAMP environment")
 			return reconcile.Result{}, nil
 		}
 		reqLogger.Info(fmt.Sprintf("running in FedRAMP zone: %s", fedrampHostedZoneID))


### PR DESCRIPTION
This updates the route53 client to follow the DNS01 challenge flow defined for fedramp clusters as described in https://issues.redhat.com/browse/OSD-8748. It checks for the presence of a FEDRAMP env var, and when present and set to True, it creates the DNS01 challenge records under a single public hosted zone in a non-govcloud account. This allows us to work around the fact that govcloud route53 only allows for private hosted zones.