### PR TITLE
Revert to setting fedramp global var outside of init()

### DIFF
--- a/pkg/clients/aws/route53.go
+++ b/pkg/clients/aws/route53.go
@@ -60,25 +60,8 @@ const (
 	configMapSTSJumpRoleField   = "sts-jump-role"
 )
 
-var fedramp bool
-var fedrampHostedZoneID string
-
-func init() {
-	envvar, present := os.LookupEnv(fedrampEnvVariable)
-	// Default to non-fedramp behavior if env variable isn't present
-	if present {
-		fedramp = envvar == "true"
-	} else {
-		fedramp = false
-	}
-
-	// The certificaterequest_controller already errors out if fedramp == True
-	// and zone_id is missing or empty
-	envvar, present = os.LookupEnv(fedrampHostedZoneIDVariable)
-	if present {
-		fedrampHostedZoneID = envvar
-	}
-}
+var fedramp = os.Getenv(fedrampEnvVariable) == "true"
+var fedrampHostedZoneID = os.Getenv(fedrampHostedZoneIDVariable)
 
 // awsClient implements the Client interface
 type awsClient struct {


### PR DESCRIPTION
From testing in stage, it appears that this init() function doesn't set the `fedramp` global variable when the newClient() method is called, so the client winds up using the wrong AWS credentials. This PR reverts to just setting the global variable outside of init(). The clusterdeployment_controller still checks for 0 length env vars and bails out if FEDRAMP=true and HOSTED_ZONE_ID isn't defined, so I think its safe to use `os.GetEnv()` here.

https://github.com/openshift/certman-operator/blob/master/pkg/controller/certificaterequest/certificaterequest_controller.go#L125-L140