### PR TITLE
Added output of response status from cloudflare

### DIFF
--- a/pkg/controller/certificaterequest/cloudflare.go
+++ b/pkg/controller/certificaterequest/cloudflare.go
@@ -129,7 +129,7 @@ func TryFetchResourceRecordUsingPublicDNS(reqLogger logr.Logger, name string) (*
 
 	response, err := FetchResourceRecordUsingPublicDNS(reqLogger, name, cloudflareDNSOverHttpsEndpoint)
 	if err != nil {
-		response, err = FetchResourceRecordUsingPublicDNS(reqLogger, name, dnsOverHttpsEndpoint)
+		response, err = FetchResourceRecordUsingPublicDNS(reqLogger, name, googleDNSOverHttpsEndpoint)
 	}
 	if err != nil {
 		localmetrics.IncrementDnsErrorCount()

--- a/pkg/controller/certificaterequest/cloudflare.go
+++ b/pkg/controller/certificaterequest/cloudflare.go
@@ -127,7 +127,7 @@ func VerifyDnsResourceRecordUpdate(reqLogger logr.Logger, fqdn string, txtValue 
 func TryFetchResourceRecordUsingPublicDNS(reqLogger logr.Logger, name string) (*DnsServerResponse, error) {
 
 
-	response, err := FetchResourceRecordUsingPublicDNS(reqLogger, name, dnsOverHttpsEndpoint)
+	response, err := FetchResourceRecordUsingPublicDNS(reqLogger, name, cloudflareDNSOverHttpsEndpoint)
 	if err != nil {
 		dnsOverHttpsEndpoint := googleDNSOverHttpsEndpoint
 		response, err = FetchResourceRecordUsingPublicDNS(reqLogger, name, dnsOverHttpsEndpoint)

--- a/pkg/controller/certificaterequest/cloudflare.go
+++ b/pkg/controller/certificaterequest/cloudflare.go
@@ -126,7 +126,6 @@ func VerifyDnsResourceRecordUpdate(reqLogger logr.Logger, fqdn string, txtValue 
 // and if that call fails (for instance, if cloudflare is down) will run FetchResourceRecordUsingPublicDNS with googleDNSOverHttpsEndpoint
 func TryFetchResourceRecordUsingPublicDNS(reqLogger logr.Logger, name string) (*DnsServerResponse, error) {
 
-	dnsOverHttpsEndpoint := cloudflareDNSOverHttpsEndpoint
 
 	response, err := FetchResourceRecordUsingPublicDNS(reqLogger, name, dnsOverHttpsEndpoint)
 	if err != nil {

--- a/pkg/controller/certificaterequest/cloudflare.go
+++ b/pkg/controller/certificaterequest/cloudflare.go
@@ -129,7 +129,6 @@ func TryFetchResourceRecordUsingPublicDNS(reqLogger logr.Logger, name string) (*
 
 	response, err := FetchResourceRecordUsingPublicDNS(reqLogger, name, cloudflareDNSOverHttpsEndpoint)
 	if err != nil {
-		dnsOverHttpsEndpoint := googleDNSOverHttpsEndpoint
 		response, err = FetchResourceRecordUsingPublicDNS(reqLogger, name, dnsOverHttpsEndpoint)
 	}
 	if err != nil {

--- a/pkg/controller/certificaterequest/constants.go
+++ b/pkg/controller/certificaterequest/constants.go
@@ -20,8 +20,9 @@ type dnsRCode int
 
 const (
 	cloudflareDNSOverHttpsEndpoint    = "https://cloudflare-dns.com/dns-query"
-	cloudflareRequestContentType      = "application/dns-json"
-	cloudflareRequestTimeout          = 60
+	googleDNSOverHttpsEndpoint        = "https://dns.google/dns-query"
+	dnsServerRequestContentType       = "application/dns-json"
+	dnsServerRequestTimeout           = 60
 	maxAttemptsForDnsPropagationCheck = 10  // Try 10 times (5 minutes total)
 	waitTimePeriodDnsPropagationCheck = 30  // Wait 30 seconds between checks
 	maxNegativeCacheTTL               = 600 // Sleep no more than 10 minutes
@@ -29,5 +30,5 @@ const (
 	rSAKeyBitSize                     = 2048
 
 	// From golang.org/x/net/dns/dnsmessage
-	dnsRCodeNameError      dnsRCode = 3
+	dnsRCodeNameError dnsRCode = 3
 )

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -80,6 +80,10 @@ var (
 		Name: "certman_operator_lets_encrypt_maintenance_error_count",
 		Help: "The number of Let's Encrypt maintenance errors received",
 	})
+	MetricDnsErrorCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cloudflare_failed_requests_count",
+		Help: "Counter on the number of failed DNS requests",
+	})
 
 	MetricsList = []prometheus.Collector{
 		MetricCertsIssuedInLastDayDevshiftOrg,
@@ -92,6 +96,7 @@ var (
 		MetricClusterDeploymentReconcileDuration,
 		MetricCertRequestsCount,
 		MetricCertIssuanceRate,
+		MetricDnsErrorCount,
 		MetricCertValidDuration,
 		MetricLetsEncryptMaintenanceErrorCount,
 	}
@@ -181,4 +186,9 @@ func UpdateCertValidDuration(cert *x509.Certificate) {
 // IncrementLetsEncryptMaintenanceErrorCount Increment the count of Let's Encrypt maintenance errors
 func IncrementLetsEncryptMaintenanceErrorCount() {
 	MetricLetsEncryptMaintenanceErrorCount.Inc()
+}
+
+// IncrementDnsErrorCount Increment the count of DNS errors
+func IncrementDnsErrorCount() {
+	MetricDnsErrorCount.Inc()
 }


### PR DESCRIPTION
In this commit, I added outputting the response status from Cloudflare with the status code into the logs; a custom local metric to count DNS failures. I added a call to google's public DNS server in case the call to Cloudflare's public DNS server fails.