### PR TITLE
OSD-1949 add a rate limiter to the certificaterequest controller

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
@@ -31,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -84,6 +86,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	o := controller.Options{
 		Reconciler:              r,
 		MaxConcurrentReconciles: maxConcurrentReconciles,
+		RateLimiter:             workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 30*time.Second),
 	}
 
 	c, err := controller.New("certificaterequest-controller", mgr, o)


### PR DESCRIPTION
this should stop certman-operator from burning through the rate limit of AWS and let's encrypt