### PR TITLE
removes support for deprecated LE secret names

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller_test.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller_test.go
@@ -46,13 +46,13 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			name:                       "errors if AWS account secret is unset",
-			clientObjects:              []runtime.Object{testStagingLESecret, certRequest, emptyCertSecret},
+			clientObjects:              []runtime.Object{testLESecret, certRequest, emptyCertSecret},
 			expectedCertificateRequest: certRequest,
 			expectError:                true,
 		},
 		{
 			name:          "update status of a new certificaterequest with old secret",
-			clientObjects: []runtime.Object{testStagingLESecret, certRequest, validCertSecret, clusterDeploymentComplete},
+			clientObjects: []runtime.Object{testLESecret, certRequest, validCertSecret, clusterDeploymentComplete},
 			expectedCertificateRequest: &certmanv1alpha1.CertificateRequest{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "CertificateRequest",
@@ -100,7 +100,7 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			name:          "don't manage certs on outgoing clusterdeployment relocation",
-			clientObjects: []runtime.Object{testStagingLESecret, clusterDeploymentOutgoing, certRequest, expiredCertSecret},
+			clientObjects: []runtime.Object{testLESecret, clusterDeploymentOutgoing, certRequest, expiredCertSecret},
 			expectedCertificateRequest: func() *certmanv1alpha1.CertificateRequest {
 				cr := &certmanv1alpha1.CertificateRequest{}
 				cr.TypeMeta = certRequest.TypeMeta
@@ -115,7 +115,7 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			name:          "do manage certs on incoming clusterdeployment relocation",
-			clientObjects: []runtime.Object{testStagingLESecret, clusterDeploymentIncoming, certRequest, validCertSecret},
+			clientObjects: []runtime.Object{testLESecret, clusterDeploymentIncoming, certRequest, validCertSecret},
 			expectedCertificateRequest: &certmanv1alpha1.CertificateRequest{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "CertificateRequest",
@@ -163,7 +163,7 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			name:          "do manage certs on complete clusterdeployment relocation",
-			clientObjects: []runtime.Object{testStagingLESecret, clusterDeploymentComplete, certRequest, validCertSecret},
+			clientObjects: []runtime.Object{testLESecret, clusterDeploymentComplete, certRequest, validCertSecret},
 			expectedCertificateRequest: &certmanv1alpha1.CertificateRequest{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "CertificateRequest",
@@ -219,7 +219,7 @@ func TestReconcile(t *testing.T) {
 				cr.Spec = certRequest.Spec
 				cr.Status = certRequest.Status
 
-				return []runtime.Object{testStagingLESecret, cr, clusterDeploymentComplete, validCertSecret}
+				return []runtime.Object{testLESecret, cr, clusterDeploymentComplete, validCertSecret}
 			}(),
 			expectedCertificateRequest: &certmanv1alpha1.CertificateRequest{
 				TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/certificaterequest/renew_certificate_test.go
+++ b/pkg/controller/certificaterequest/renew_certificate_test.go
@@ -39,7 +39,7 @@ func TestShouldReissue(t *testing.T) {
 	}
 
 	//set up empty test client
-	testClient := setUpTestClient(t, []runtime.Object{testStagingLESecret, certRequest, emptyCertSecret})
+	testClient := setUpTestClient(t, []runtime.Object{testLESecret, certRequest, emptyCertSecret})
 	//create a reconcile certificate object
 	rcr := ReconcileCertificateRequest{
 		client:        testClient,

--- a/pkg/controller/certificaterequest/test_helpers.go
+++ b/pkg/controller/certificaterequest/test_helpers.go
@@ -202,10 +202,10 @@ Yiu4AbJf3ISUdPj0QlWOcw0kGEXLC/w2dw==
 
 // mock secrets for letsencrypt accounts. these use the above ES236 key and
 // should not be used for anything else
-var testStagingLESecret = &corev1.Secret{
+var testLESecret = &corev1.Secret{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: config.OperatorNamespace,
-		Name:      "lets-encrypt-account-staging",
+		Name:      "lets-encrypt-account",
 	},
 	Data: map[string][]byte{
 		"private-key": leAccountPrivKey,

--- a/pkg/leclient/lets_encrypt.go
+++ b/pkg/leclient/lets_encrypt.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/eggsampler/acme"
 	v1 "k8s.io/api/core/v1"
-	kerr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/certman-operator/config"
@@ -233,18 +232,6 @@ func getLetsEncryptAccountSecret(kubeClient client.Client) (secret *v1.Secret, e
 	secretName := letsEncryptAccountSecretName
 
 	secret, err = GetSecret(kubeClient, secretName, config.OperatorNamespace)
-	if err != nil {
-		// If it's not found err, try to use the legacy production secret name for backward compatibility
-		if kerr.IsNotFound(err) {
-			secretName = letsEncryptProductionAccountSecretName
-			secret, err = GetSecret(kubeClient, secretName, config.OperatorNamespace)
-			// If it's not found err, try to use the legacy staging secret name for backward compatibility
-			if kerr.IsNotFound(err) {
-				secretName = letsEncryptStagingAccountSecretName
-				secret, err = GetSecret(kubeClient, secretName, config.OperatorNamespace)
-			}
-		}
-	}
 	return
 }
 

--- a/pkg/leclient/lets_encrypt.go
+++ b/pkg/leclient/lets_encrypt.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/eggsampler/acme"
-	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/certman-operator/config"
@@ -192,7 +191,7 @@ func (c *ACMEClient) RevokeCertificate(certificate *x509.Certificate) (err error
 // getLetsEncryptAccountPrivateKey accepts client.Client as kubeClient and retrieves the
 // letsEncrypt account secret. The PrivateKey is de
 func getLetsEncryptAccountPrivateKey(kubeClient client.Client) (privateKey crypto.Signer, err error) {
-	secret, err := getLetsEncryptAccountSecret(kubeClient)
+	secret, err := GetSecret(kubeClient, letsEncryptAccountSecretName, config.OperatorNamespace)
 	if err != nil {
 		return privateKey, err
 	}
@@ -216,7 +215,7 @@ func getLetsEncryptAccountPrivateKey(kubeClient client.Client) (privateKey crypt
 }
 
 func getLetsEncryptAccountURL(kubeClient client.Client) (url string, err error) {
-	secret, err := getLetsEncryptAccountSecret(kubeClient)
+	secret, err := GetSecret(kubeClient, letsEncryptAccountSecretName, config.OperatorNamespace)
 	if err != nil {
 		return url, err
 	}
@@ -226,13 +225,6 @@ func getLetsEncryptAccountURL(kubeClient client.Client) (url string, err error) 
 	url = strings.TrimRight(url, "\n")
 
 	return url, nil
-}
-
-func getLetsEncryptAccountSecret(kubeClient client.Client) (secret *v1.Secret, err error) {
-	secretName := letsEncryptAccountSecretName
-
-	secret, err = GetSecret(kubeClient, secretName, config.OperatorNamespace)
-	return
 }
 
 // NewClient accepts a client.Client as kubeClient and calls the acme NewClient func.

--- a/pkg/leclient/lets_encrypt_test.go
+++ b/pkg/leclient/lets_encrypt_test.go
@@ -34,59 +34,6 @@ sigs.k8s.io/controller-runtime/pkg/client/fake is supposed to be deprecated but 
 https://github.com/operator-framework/operator-sdk/blob/master/doc/user/unit-testing.md
 */
 
-func TestGetLetsEncryptAccountSecret(t *testing.T) {
-	t.Run("returns an error", func(t *testing.T) {
-		t.Run("if there's no secret", func(t *testing.T) {
-			testClient := setUpEmptyTestClient(t)
-
-			_, actual := getLetsEncryptAccountSecret(testClient)
-
-			if actual == nil {
-				t.Error("expected an error when attempting to get missing account secrets")
-			}
-		})
-
-		t.Run("if only deprecated staging secret is set", func(t *testing.T) {
-			testClient := setUpTestClient(t, letsEncryptStagingAccountSecretName)
-
-			// this will return an error if the secret is missing
-			_, err := getLetsEncryptAccountSecret(testClient)
-			if !kerr.IsNotFound(err) {
-				t.Error("expected an error when using deprecated secret name")
-			}
-		})
-
-		t.Run("if only deprecated production secret is set", func(t *testing.T) {
-			testClient := setUpTestClient(t, letsEncryptProductionAccountSecretName)
-
-			// this will return an error if the secret is missing
-			_, err := getLetsEncryptAccountSecret(testClient)
-			if !kerr.IsNotFound(err) {
-				t.Error("expected an error when using deprecated secret name")
-			}
-		})
-	})
-
-	t.Run("returns a secret", func(t *testing.T) {
-		t.Run("if only approved secret is set", func(t *testing.T) {
-			testClient := setUpTestClient(t, letsEncryptAccountSecretName)
-
-			// this will return an error if the secret is missing
-			secret, err := getLetsEncryptAccountSecret(testClient)
-			if err != nil {
-				t.Fatalf("got an unexpected error retrieving the account secret: %q", err)
-			}
-
-			actual := secret.Name
-			expected := letsEncryptAccountSecretName
-
-			if actual != expected {
-				t.Errorf("got %q expected %q", actual, expected)
-			}
-		})
-	})
-}
-
 func TestNewClient(t *testing.T) {
 	t.Run("returns an error", func(t *testing.T) {
 		t.Run("if no account secret is found", func(t *testing.T) {

--- a/pkg/leclient/lets_encrypt_test.go
+++ b/pkg/leclient/lets_encrypt_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openshift/certman-operator/config"
 	"k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,66 +35,103 @@ https://github.com/operator-framework/operator-sdk/blob/master/doc/user/unit-tes
 */
 
 func TestGetLetsEncryptAccountSecret(t *testing.T) {
-	t.Run("returns an error if no secret is found", func(t *testing.T) {
-		testClient := setUpEmptyTestClient(t)
+	t.Run("returns an error", func(t *testing.T) {
+		t.Run("if there's no secret", func(t *testing.T) {
+			testClient := setUpEmptyTestClient(t)
 
-		_, actual := getLetsEncryptAccountSecret(testClient)
+			_, actual := getLetsEncryptAccountSecret(testClient)
 
-		if actual == nil {
-			t.Errorf("expected an error when attempting to get missing account secrets")
-		}
-	})
+			if actual == nil {
+				t.Error("expected an error when attempting to get missing account secrets")
+			}
+		})
 
-	t.Run("returns a secret", func(t *testing.T) {
 		t.Run("if only deprecated staging secret is set", func(t *testing.T) {
 			testClient := setUpTestClient(t, letsEncryptStagingAccountSecretName)
 
-			verifyAccountSecret(t, testClient, letsEncryptStagingAccountSecretName)
+			// this will return an error if the secret is missing
+			_, err := getLetsEncryptAccountSecret(testClient)
+			if !kerr.IsNotFound(err) {
+				t.Error("expected an error when using deprecated secret name")
+			}
 		})
 
 		t.Run("if only deprecated production secret is set", func(t *testing.T) {
 			testClient := setUpTestClient(t, letsEncryptProductionAccountSecretName)
 
-			verifyAccountSecret(t, testClient, letsEncryptProductionAccountSecretName)
+			// this will return an error if the secret is missing
+			_, err := getLetsEncryptAccountSecret(testClient)
+			if !kerr.IsNotFound(err) {
+				t.Error("expected an error when using deprecated secret name")
+			}
 		})
+	})
 
+	t.Run("returns a secret", func(t *testing.T) {
 		t.Run("if only approved secret is set", func(t *testing.T) {
 			testClient := setUpTestClient(t, letsEncryptAccountSecretName)
 
-			verifyAccountSecret(t, testClient, letsEncryptAccountSecretName)
-		})
+			// this will return an error if the secret is missing
+			secret, err := getLetsEncryptAccountSecret(testClient)
+			if err != nil {
+				t.Fatalf("got an unexpected error retrieving the account secret: %q", err)
+			}
 
+			actual := secret.Name
+			expected := letsEncryptAccountSecretName
+
+			if actual != expected {
+				t.Errorf("got %q expected %q", actual, expected)
+			}
+		})
 	})
 }
 
 func TestNewClient(t *testing.T) {
-	t.Run("returns an error if no account secret is found", func(t *testing.T) {
-		testClient := setUpEmptyTestClient(t)
+	t.Run("returns an error", func(t *testing.T) {
+		t.Run("if no account secret is found", func(t *testing.T) {
+			testClient := setUpEmptyTestClient(t)
 
-		_, actual := NewClient(testClient)
+			_, actual := NewClient(testClient)
 
-		if actual == nil {
-			t.Errorf("expected an error when attempting to get missing account secrets")
-		}
-	})
+			if actual == nil {
+				t.Errorf("expected an error when attempting to get missing account secrets")
+			}
+		})
 
-	t.Run("returns an leclient", func(t *testing.T) {
 		t.Run("if only deprecated staging secret is set", func(t *testing.T) {
 			testClient := setUpTestClient(t, letsEncryptStagingAccountSecretName)
 
-			verifyLEClient(t, testClient)
+			_, err := NewClient(testClient)
+
+			if !kerr.IsNotFound(err) {
+				t.Error("expected error when using deprecated secret name")
+			}
 		})
 
 		t.Run("if only deprecated production secret is set", func(t *testing.T) {
 			testClient := setUpTestClient(t, letsEncryptProductionAccountSecretName)
 
-			verifyLEClient(t, testClient)
-		})
+			_, err := NewClient(testClient)
 
+			if !kerr.IsNotFound(err) {
+				t.Error("expected error when using deprecated secret name")
+			}
+		})
+	})
+
+	t.Run("returns an leclient", func(t *testing.T) {
 		t.Run("if only approved secret is set", func(t *testing.T) {
 			testClient := setUpTestClient(t, letsEncryptAccountSecretName)
 
-			verifyLEClient(t, testClient)
+			leclient, err := NewClient(testClient)
+			if err != nil {
+				t.Fatalf("unexpected error creating the leclient: %q", err)
+			}
+
+			if leclient == nil {
+				t.Errorf("leclient failed to set up")
+			}
 		})
 	})
 }
@@ -141,41 +179,4 @@ func setUpTestClient(t *testing.T, accountSecretName string) (testClient client.
 
 	testClient = fake.NewFakeClient(objects...)
 	return
-}
-
-/*
-Confirm that `leclient.getLetsEncryptAccountSecret()` returns the right secret.
-Takes a kube client and the name of the secret to confirm was retrieved. The
-kube client should already have the secret created in it.
-*/
-func verifyAccountSecret(t *testing.T, testClient client.Client, secretName string) {
-	t.Helper()
-
-	// this will return an error if the secret is missing
-	secret, err := getLetsEncryptAccountSecret(testClient)
-	if err != nil {
-		t.Fatalf("got an unexpected error retrieving the account secret: %q", err)
-	}
-
-	actual := secret.Name
-	expected := secretName
-
-	if actual != expected {
-		t.Errorf("got %q expected %q", actual, expected)
-	}
-}
-
-/*
-Confirm that `leclient.NewClient` returns an ACMEClient. Takes a kube client
-with the secret created in it.
-*/
-func verifyLEClient(t *testing.T, testClient client.Client) {
-	leclient, err := NewClient(testClient)
-	if err != nil {
-		t.Fatalf("unexpected error creating the leclient: %q", err)
-	}
-
-	if leclient == nil {
-		t.Errorf("leclient failed to set up")
-	}
 }


### PR DESCRIPTION
the secret names lets-encrypt-account-staging and lets-encrypt-account-production have been deprecated for a while now. this commit removes support for using those names, only looking for the standard secret name: lets-encrypt-account 