### PR TITLE
follow owner reference to find clusterdeployment if possible

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -203,14 +203,15 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 			reqLogger.Error(err, err.Error())
 			return reconcile.Result{}, err
 		}
-		clusterDeploymentName = cdList.Items[0].Name
 
 		// if we still can't find a clusterdeployment, throw an error
-		if clusterDeploymentName == "" {
+		if len(cdList.Items) == 0 {
 			err = gerrors.New("ClusterDeployment not found")
 			reqLogger.Error(err, "ClusterDeployment not found")
 			return reconcile.Result{}, err
 		}
+
+		clusterDeploymentName = cdList.Items[0].Name
 	}
 
 	cd := &hivev1.ClusterDeployment{}

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -57,6 +57,7 @@ const (
 	hiveRelocationCertificateRequstStatus = "Not reconciling: ClusterDeployment is relocating"
 	fedrampEnvVariable                    = "FEDRAMP"
 	fedrampHostedZoneIDVariable           = "HOSTED_ZONE_ID"
+	clusterDeploymentType                 = "ClusterDeployment"
 )
 
 var fedramp = os.Getenv(fedrampEnvVariable) == "true"
@@ -190,7 +191,7 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 	clusterDeploymentName := ""
 
 	for _, o := range cr.ObjectMeta.OwnerReferences {
-		if o.Kind == "ClusterDeployment" {
+		if o.Kind == clusterDeploymentType {
 			clusterDeploymentName = o.Name
 		}
 	}

--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -55,7 +55,6 @@ const (
 	hiveRelocationAnnotation              = "hive.openshift.io/relocate"
 	hiveRelocationOutgoingValue           = "outgoing"
 	hiveRelocationCertificateRequstStatus = "Not reconciling: ClusterDeployment is relocating"
-	certRequestSuffix                     = "-primary-cert-bundle"
 	fedrampEnvVariable                    = "FEDRAMP"
 	fedrampHostedZoneIDVariable           = "HOSTED_ZONE_ID"
 )
@@ -185,14 +184,35 @@ func (r *ReconcileCertificateRequest) Reconcile(request reconcile.Request) (reco
 		}
 	}
 
-	// assume there's only one clusterdeployment in a namespace and that it's the owner of this certificaterequest
-	// we have to assume this so that if/when a CertificateRequest loses its OwnerReferences, it can still reconcile
-	clusterDeploymentName := strings.Split(request.NamespacedName.Name, certRequestSuffix)[0]
-	if clusterDeploymentName == "" {
-		err = gerrors.New("ClusterDeployment not found")
-		reqLogger.Error(err, "ClusterDeployment not found")
-		return reconcile.Result{}, err
+	// just in case something else ever adds itself as an owner of the
+	// certificaterequest, loop through the owner references to find which one is
+	// the clusterdeployment
+	clusterDeploymentName := ""
+
+	for _, o := range cr.ObjectMeta.OwnerReferences {
+		if o.Kind == "ClusterDeployment" {
+			clusterDeploymentName = o.Name
+		}
 	}
+	if clusterDeploymentName == "" {
+		// assume there's only one clusterdeployment in a namespace and that it's the owner of this certificaterequest
+		// we have to assume this so that if/when a CertificateRequest loses its OwnerReferences, it can still reconcile
+		cdList := &hivev1.ClusterDeploymentList{}
+		err = r.client.List(context.TODO(), cdList)
+		if err != nil {
+			reqLogger.Error(err, err.Error())
+			return reconcile.Result{}, err
+		}
+		clusterDeploymentName = cdList.Items[0].Name
+
+		// if we still can't find a clusterdeployment, throw an error
+		if clusterDeploymentName == "" {
+			err = gerrors.New("ClusterDeployment not found")
+			reqLogger.Error(err, "ClusterDeployment not found")
+			return reconcile.Result{}, err
+		}
+	}
+
 	cd := &hivev1.ClusterDeployment{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: request.Namespace, Name: clusterDeploymentName}, cd)
 	if err != nil {

--- a/pkg/controller/certificaterequest/certificaterequest_controller_test.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller_test.go
@@ -280,22 +280,22 @@ func TestReconcile(t *testing.T) {
 				//cr.ObjectMeta.OwnerReferences = []metav1.OwnerReference{} // this should already be set to actual owner refs by ^
 				cr.Spec = certRequest.Spec
 				// cr.Status = certRequest.Status // need to test that it sets the status
-				cr.Spec.CertificateSecret.Name = "ocm-cert-bundle-secret"
+				cr.Spec.CertificateSecret.Name = "foobar-cert-bundle-secret"
 
 				// generate an leclient using a mock acme client
 				newClientSecret := testLESecret
 				newClientSecret.Data["account-url"] = []byte("proto://use.mock.acme.client")
 				clusterDeploymentComplete.Spec.CertificateBundles = append(clusterDeploymentComplete.Spec.CertificateBundles, hivev1.CertificateBundleSpec{
-					Name:     "ocm-cert-bundle-secret",
+					Name:     "foobar-cert-bundle-secret",
 					Generate: true,
 					CertificateSecretRef: corev1.LocalObjectReference{
-						Name: "ocm-cert-bundle-secret",
+						Name: "foobar-cert-bundle-secret",
 					},
 				})
 				clusterDeploymentComplete.Spec.Ingress = append(clusterDeploymentComplete.Spec.Ingress, hivev1.ClusterIngress{
-					Name:               "ocm",
-					Domain:             "ocm.whatever.hostname.tld",
-					ServingCertificate: "ocm-cert-bundle-secret",
+					Name:               "foobar",
+					Domain:             "foobar.whatever.hostname.tld",
+					ServingCertificate: "foobar-cert-bundle-secret",
 				})
 
 				return []runtime.Object{newClientSecret, cr, clusterDeploymentComplete}
@@ -324,7 +324,7 @@ func TestReconcile(t *testing.T) {
 					CertificateSecret: corev1.ObjectReference{
 						Kind:      "Secret",
 						Namespace: testHiveNamespace,
-						Name:      "ocm-cert-bundle-secret",
+						Name:      "foobar-cert-bundle-secret",
 					},
 					Platform: certmanv1alpha1.Platform{},
 					DnsNames: []string{

--- a/pkg/controller/certificaterequest/certificaterequest_controller_test.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -210,16 +211,20 @@ func TestReconcile(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "discover clusterdeployment if certrequest ownerref is missing",
+			name: "reqeusts a new cert",
 			clientObjects: func() []runtime.Object {
 				cr := &certmanv1alpha1.CertificateRequest{}
 				cr.TypeMeta = certRequest.TypeMeta
 				cr.ObjectMeta = certRequest.ObjectMeta
-				cr.ObjectMeta.OwnerReferences = []metav1.OwnerReference{}
+				//cr.ObjectMeta.OwnerReferences = []metav1.OwnerReference{} // this should already be set to actual owner refs by ^
 				cr.Spec = certRequest.Spec
-				cr.Status = certRequest.Status
+				// cr.Status = certRequest.Status // need to test that it sets the status
 
-				return []runtime.Object{testLESecret, cr, clusterDeploymentComplete, validCertSecret}
+				// generate an leclient using a mock acme client
+				newClientSecret := testLESecret
+				newClientSecret.Data["account-url"] = []byte("proto://use.mock.acme.client")
+
+				return []runtime.Object{newClientSecret, cr, clusterDeploymentComplete}
 			}(),
 			expectedCertificateRequest: &certmanv1alpha1.CertificateRequest{
 				TypeMeta: metav1.TypeMeta{
@@ -267,7 +272,7 @@ func TestReconcile(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "reqeusts a new cert",
+			name: "handles multiple ingresses and cert secrets",
 			clientObjects: func() []runtime.Object {
 				cr := &certmanv1alpha1.CertificateRequest{}
 				cr.TypeMeta = certRequest.TypeMeta
@@ -275,10 +280,23 @@ func TestReconcile(t *testing.T) {
 				//cr.ObjectMeta.OwnerReferences = []metav1.OwnerReference{} // this should already be set to actual owner refs by ^
 				cr.Spec = certRequest.Spec
 				// cr.Status = certRequest.Status // need to test that it sets the status
+				cr.Spec.CertificateSecret.Name = "ocm-cert-bundle-secret"
 
 				// generate an leclient using a mock acme client
 				newClientSecret := testLESecret
 				newClientSecret.Data["account-url"] = []byte("proto://use.mock.acme.client")
+				clusterDeploymentComplete.Spec.CertificateBundles = append(clusterDeploymentComplete.Spec.CertificateBundles, hivev1.CertificateBundleSpec{
+					Name:     "ocm-cert-bundle-secret",
+					Generate: true,
+					CertificateSecretRef: corev1.LocalObjectReference{
+						Name: "ocm-cert-bundle-secret",
+					},
+				})
+				clusterDeploymentComplete.Spec.Ingress = append(clusterDeploymentComplete.Spec.Ingress, hivev1.ClusterIngress{
+					Name:               "ocm",
+					Domain:             "ocm.whatever.hostname.tld",
+					ServingCertificate: "ocm-cert-bundle-secret",
+				})
 
 				return []runtime.Object{newClientSecret, cr, clusterDeploymentComplete}
 			}(),
@@ -306,7 +324,7 @@ func TestReconcile(t *testing.T) {
 					CertificateSecret: corev1.ObjectReference{
 						Kind:      "Secret",
 						Namespace: testHiveNamespace,
-						Name:      testHiveSecretName,
+						Name:      "ocm-cert-bundle-secret",
 					},
 					Platform: certmanv1alpha1.Platform{},
 					DnsNames: []string{


### PR DESCRIPTION
this should avoid a case where a certificaterequest using a
certificateSecret with a name other than "clustername-primary-cert-bundle" can
find the clusterdeployment and reconcile

for [OSD-11949](https://issues.redhat.com//browse/OSD-11949)