### PR TITLE
Update documentation for migrated certman-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,3 @@ SHELL := /usr/bin/env bash
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
-
-.PHONY: run
-run: ## Run certman-operator locally
-	WATCH_NAMESPACE="certman-operator" OPERATOR_NAME="certman-operator" go run ./main.go
-
-.PHONY: help
-help: ## Show this help screen.
-	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
-	@echo ''
-	@echo 'Available targets are:'
-	@echo ''
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | sed 's/##//g' | awk 'BEGIN {FS = ":"}; {printf "\033[36m%-30s\033[0m %s\n", $$2, $$3}'

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,15 @@ SHELL := /usr/bin/env bash
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
+
+.PHONY: run
+run: ## Run certman-operator locally
+	OPERATOR_NAME="certman-operator" go run ./main.go
+
+.PHONY: help
+help: ## Show this help screen.
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | sed 's/##//g' | awk 'BEGIN {FS = ":"}; {printf "\033[36m%-30s\033[0m %s\n", $$2, $$3}'

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ boilerplate-update:
 
 .PHONY: run
 run: ## Run certman-operator locally
-	OPERATOR_NAME="certman-operator" go run ./main.go
+	WATCH_NAMESPACE="certman-operator" OPERATOR_NAME="certman-operator" go run ./main.go
 
 .PHONY: help
 help: ## Show this help screen.

--- a/README.md
+++ b/README.md
@@ -30,19 +30,20 @@
   - [License](#license)
 
 ## About
-The Certman Operator is used to automate the provisioning and management of TLS certificates from [Let's Encrypt](https://letsencrypt.org/) for [OpenShift Dedicated](https://www.openshift.com/products/dedicated/) clusters provisioned via https://cloud.redhat.com/.
+
+The Certman Operator is used to automate the provisioning and management of TLS certificates from [Let's Encrypt](https://letsencrypt.org/) for [OpenShift Dedicated](https://www.openshift.com/products/dedicated/) clusters provisioned via <https://cloud.redhat.com/>.
 
 At a high level, Certman Operator is responsible for:
 
-* Provisioning Certificates after a cluster's successful installation.
-* Reissuing Certificates prior to their expiry.
-* Revoking Certificates upon cluster decomissioning.
+- Provisioning Certificates after a cluster's successful installation.
+- Reissuing Certificates prior to their expiry.
+- Revoking Certificates upon cluster decomissioning.
 
 ## Dependencies
 
-**GO:** 1.13
+**GO:** 1.17
 
-**Operator-SDK:** 0.16.0
+**Operator-SDK:** 1.21.0
 
 **Hive:** v1
 
@@ -54,11 +55,11 @@ Only Hive v1 will work with this release.
 
 ## How the Certman Operator works
 
-1. A new OpenShift Dedicated cluster is requested from https://cloud.redhat.com.
+1. A new OpenShift Dedicated cluster is requested from <https://cloud.redhat.com>.
 1. The clusterdeployment controller's `Reconcile` function watches the `Installed` field of the ClusterDeployment CRD (as explained above). Once the `Installed` field becomes `true`, a [CertificateRequest](https://github.com/openshift/certman-operator/blob/master/deploy/crds/certman.managed.openshift.io_certificaterequests_crd.yaml) resource is created for that cluster.
 1. Certman operator will then request new certificates from Let’s Encrypt based on the populated spec fields of the CertificateRequest CRD.
 1. To prove ownership of the domain, Certman will attempt to answer the Let’s Encrypt [DNS-01 challenge](https://letsencrypt.org/docs/challenge-types/) by publishing the `_acme-challenge` subdomain in the cluster’s DNS zone with a TTL of 1 min.
-1. Wait for propagation of the record and then verify the existance of the challenge subdomain by using DNS over HTTPS service from Cloudflare. Certman will retry verification up to 5 times before erroring.
+1. Wait for propagation of the record and then verify the existence of the challenge subdomain by using DNS over HTTPS service from Cloudflare. Certman will retry verification up to 5 times before erroring.
 1. Once the challenge subdomain record has been verified, Let’s Encrypt can verify that you are in control of the domain’s DNS.
 1. Let’s Encrypt will issue certificates once the challenge has been successfuly completed. Certman will then delete the challenge subdomain as it is no longer required.
 1. Certificates are then stored in a secret on the management cluster. Hive watches for this secret.
@@ -69,18 +70,18 @@ Only Hive v1 will work with this release.
 
 ## Limitations
 
-* As described above in dependencies, Certman Operator requires [Hive](https://github.com/openshift/hive) for custom resources and actual deployment of certificates. It is therefore **not** a suitable "out-of-the-box" solution for Let's Encrypt certificate management. For this, we recommend using either [openshift-acme](https://github.com/tnozicka/openshift-acme) or [cert-manager](https://github.com/jetstack/cert-manager). Certman Operator is ideal for use cases when a large number of OpenShift clusters have to be managed centrally.
-* Certman Operator currently only supports [DNS Challenges](https://tools.ietf.org/html/rfc8555#section-8.4) through AWS Route53. There are plans for GCP support. [HTTP Challenges](https://tools.ietf.org/html/rfc8555#section-8.3) is not supported.
-* Certman Operator does not support creation of Let's Encrypt accounts at this time. You must already have a Let's Encrypt account and keys that you can provide to the Certman Operator.
-* Certman Operator does NOT configure the TLS certificates in an OpenShift cluster. This is managed by [Hive](https://github.com/openshift/hive) using [SyncSet](https://github.com/openshift/hive/blob/master/docs/syncset.md).
+- As described above in dependencies, Certman Operator requires [Hive](https://github.com/openshift/hive) for custom resources and actual deployment of certificates. It is therefore **not** a suitable "out-of-the-box" solution for Let's Encrypt certificate management. For this, we recommend using either [openshift-acme](https://github.com/tnozicka/openshift-acme) or [cert-manager](https://github.com/jetstack/cert-manager). Certman Operator is ideal for use cases when a large number of OpenShift clusters have to be managed centrally.
+- Certman Operator currently only supports [DNS Challenges](https://tools.ietf.org/html/rfc8555#section-8.4) through AWS Route53. There are plans for GCP support. [HTTP Challenges](https://tools.ietf.org/html/rfc8555#section-8.3) is not supported.
+- Certman Operator does not support creation of Let's Encrypt accounts at this time. You must already have a Let's Encrypt account and keys that you can provide to the Certman Operator.
+- Certman Operator does NOT configure the TLS certificates in an OpenShift cluster. This is managed by [Hive](https://github.com/openshift/hive) using [SyncSet](https://github.com/openshift/hive/blob/master/docs/syncset.md).
 
 ## CustomResourceDefinitions
 
 The Certman Operator relies on the following custom resource definitions (CRDs):
 
-* **`CertificateRequest`**, which provides the details needed to request a certificate from Let's Encrypt.
+- **`CertificateRequest`**, which provides the details needed to request a certificate from Let's Encrypt.
 
-* **`ClusterDeployment`**, which defines a targeted OpenShift managed cluster. The Operator ensures at all times that the OpenShift managed cluster has valid certificates for control plane and pre-defined external routes.
+- **`ClusterDeployment`**, which defines a targeted OpenShift managed cluster. The Operator ensures at all times that the OpenShift managed cluster has valid certificates for control plane and pre-defined external routes.
 
 ## Setup Certman Operator
 
@@ -92,75 +93,76 @@ The script `hack/test/local_test.sh` can be used to automate local testing by cr
 
 ### Certman Operator Configuration
 
-A [ConfigMap](https://docs.openshift.com/container-platform/3.11/dev_guide/configmaps.html) is used to store certman operator configuration. The ConfigMap contains one value, `default_notification_email_address`, the email address to which Let's Encrypt certificate expiry notifications should be sent.
+A [ConfigMap](https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configmaps.html) is used to store certman operator configuration. The ConfigMap contains one value, `default_notification_email_address`, the email address to which Let's Encrypt certificate expiry notifications should be sent.
 
-```
+```shell
 oc create configmap certman-operator \
     --from-literal=default_notification_email_address=foo@bar.com
 ```
 
 ### Certman Operator Secrets
 
-A [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) is used to store the Let's Encrypt account url and keys.
+There are two [secrets](https://kubernetes.io/docs/concepts/configuration/secret/) required for certman-operator to function.
 
+1. `lets-encrypt-account` - This secret is used to store the Let's Encrypt account url and keys.
+
+```shell
+ oc create secret generic lets-encrypt-account \
+    --from-file=private-key=private-key.pem \
+    --from-file=account-url=account.txt
 ```
- oc create secret generic lets-encrypt-account-staging \
-    --from-file=private-key=production-private-key.pem \
-    --from-file=account-url=production-account.txt
- oc create secret generic lets-encrypt-account-production \
-    --from-file=private-key=staging-private-key.pem \
-    --from-file=account-url=staging-account.txt
+
+2. `aws` or `gcp` - Based on which platform is being used (AWS or GCP), this is another secret which contains the cloud platform credentials.
+
+```bash
+oc -n certman-operator create secret generic aws --from-literal=aws_access_key_id=XXX 
+--from-literal=aws_secret_access_key=YYYY 
 ```
+
+*NOTE: For testing purposes, both the secrets can be found on the Hive shard of the staging cluster.*
 
 ### Custom Resource Definitions (CRDs)
 
 #### Create Hive CRDs
 
-```
+```shell
 git clone git@github.com:openshift/hive.git
 oc create -f hive/config/crds
 ```
 
 #### Create Certman Operator CRDs
 
-```
-oc create -f https://raw.githubusercontent.com/openshift/certman-operator/master/deploy/crds/certman.managed.openshift.io_certificaterequests_crd.yaml
+```shell
+oc create -f https://raw.githubusercontent.com/openshift/certman-operator/master/deploy/crds/certman.managed.openshift.io_certificaterequests.yaml
 ```
 
 ### Run Operator From Source
 
-```
-operator-sdk run --local
+```shell
+make run
 ```
 
 ### Build Operator Image
 
-```
-docker login quay.io
-
-operator-sdk build quay.io/tparikh/certman-operator
-
-docker push quay.io/tparikh/certman-operator
-```
+To build the certman-operator image, can follow the [documentation](https://github.com/openshift/boilerplate/blob/master/boilerplate/openshift/golang-osd-operator/app-sre.md).
 
 ### Setup & Deploy Operator On OpenShift/Kubernetes Cluster
 
-#### Create & Use OpenShift Project
+#### Create & Use certman-operator Project
 
-```
+```shell
 oc new-project certman-operator
-oc label namespace certman-operator release=monitoring
 ```
 
-####  Setup Service Account
+#### Setup Service Account
 
-```
+```shell
 oc create -f deploy/service_account.yaml
 ```
 
 #### Setup RBAC
 
-```
+```shell
 oc create -f deploy/role.yaml
 oc create -f deploy/role_binding.yaml
 ```
@@ -168,7 +170,8 @@ oc create -f deploy/role_binding.yaml
 #### Deploy the Operator
 
 Edit [deploy/operator.yaml](deploy/operator.yaml), substituting the reference to the `image` you built above. Then deploy it:
-```
+
+```shell
 oc create -f deploy/operator.yaml
 ```
 
@@ -190,7 +193,8 @@ oc create -f deploy/operator.yaml
 
 Certman Operator always creates a certificate for the control plane for the clusters Hive builds. By passing a string into the pod as an environment variable named `EXTRA_RECORD` Certman Operator can add an additional record to the SAN of the certificate for the API servers. This string should be the short hostname without the domain. The record will use the same domain as the rest of the cluster for this new record.
 Example
-```
+
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -203,7 +207,9 @@ spec:
       - name: EXTRA_RECORD
         value: "myapi"
 ```
+
 The example will add `myapi.<clustername>.<clusterdomain>` to the certificate of the control plane.
+
 ## License
 
 Certman Operator is licensed under Apache 2.0 license. See the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -118,14 +118,27 @@ There are two [secrets](https://kubernetes.io/docs/concepts/configuration/secret
     --from-file=account-url=account.txt
 ```
 
-2. `aws` or `gcp` - Based on which platform is being used (AWS or GCP), this is another secret which contains the cloud platform credentials.
+2. `aws` or `gcp` - Based on which platform is being used (AWS or GCP), this is the secret which contains the cloud platform credentials of the account of the target cluster.
 
 ```bash
+# To fetch the "aws" secret for a cluster on the Hive shard.
+NAMESPACE=$(oc get cd -A | grep -i $CLUSTERNAME | awk '{ print $1 }')
+oc -n $NAMESPACE get secret aws -oyaml
+```
+
+For testing purpose:
+
+```bash
+# To create the "aws" secret on staging cluster for testing.
 oc -n certman-operator create secret generic aws --from-literal=aws_access_key_id=XXX 
 --from-literal=aws_secret_access_key=YYYY 
 ```
 
-*NOTE: For testing purposes, both the secrets can be found on the Hive shard of the staging cluster.*
+*NOTE:*
+
+- *The above secret for AWS will be required for only non-STS clusters. The STS clusters won't have this secret.*
+
+- *For testing purposes, both the secrets can be found on the Hive shard of the staging cluster.*
 
 ### Custom Resource Definitions (CRDs)
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,16 @@ There are two [secrets](https://kubernetes.io/docs/concepts/configuration/secret
 
 1. `lets-encrypt-account` - This secret is used to store the Let's Encrypt account url and keys.
 
-```shell
- oc create secret generic lets-encrypt-account \
+```bash
+# To fetch the "lets-encrypt-account" secret for a cluster on the Hive shard.
+oc -n certman-operator get secret lets-encrypt-account -oyaml
+```
+
+For testing purposes:
+
+```bash
+# On the staging cluster:
+oc -n certman-operator create secret generic lets-encrypt-account \
     --from-file=private-key=private-key.pem \
     --from-file=account-url=account.txt
 ```
@@ -136,9 +144,9 @@ oc -n certman-operator create secret generic aws --from-literal=aws_access_key_i
 
 *NOTE:*
 
-- *The above secret for AWS will be required for only non-STS clusters. The STS clusters won't have this secret.*
+- *The 'aws' secret for AWS platform will be required for only non-STS clusters. The STS clusters won't have this secret.*
 
-- *For testing purposes, both the secrets can be found on the Hive shard of the staging cluster.*
+- *For testing purposes, both the secrets (i.e lets-encrypt-account secret and aws/gcp platform credential secret) can be found on the Hive shard of the staging cluster.*
 
 ### Custom Resource Definitions (CRDs)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Specifically, Hive provides a [namespace scoped](https://github.com/openshift/hi
 
 Only Hive v1 will work with this release.
 
+While development, make sure to run below command to fetch compatible Golang modules for Go 1.17:
+
+```shell
+go mod tidy -compat=1.17
+```
+
 ## How the Certman Operator works
 
 1. A new OpenShift Dedicated cluster is requested from <https://cloud.redhat.com>.
@@ -213,4 +219,3 @@ The example will add `myapi.<clustername>.<clusterdomain>` to the certificate of
 ## License
 
 Certman Operator is licensed under Apache 2.0 license. See the [LICENSE](LICENSE) file for details.
-

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ oc create -f https://raw.githubusercontent.com/openshift/certman-operator/master
 ### Run Operator From Source
 
 ```shell
-make run
+WATCH_NAMESPACE="certman-operator" OPERATOR_NAME="certman-operator" go run main.go
 ```
 
 ### Build Operator Image

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -81,7 +81,7 @@ oc create -f deploy/operator.yaml
 For local developement the easiest way is the use the operator-sdk cli. This will run from the local directory and use local KUBECONFIG environment variable, default `~/.kube/config`
 
 ```bash
-make run
+WATCH_NAMESPACE="certman-operator" OPERATOR_NAME="certman-operator" go run main.go
 ```
 
 ## Optional: Run in cluster

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,46 +1,58 @@
-## Setting up Certman Operator for local dev
-### Requirements
+# Setting up Certman Operator for local dev
+
+## Requirements
+
 To develop Certman Operator you will need the following:
 
-* Access to the hive repo, https://github.com/openshift/hive
-* Let’s Encrypt account id and private key.
+* Access to the hive repo, <https://github.com/openshift/hive>
+* Let’s Encrypt account id and private key
 * AWS keys and secret keys for the account you’re using.
 * An OpenShift test cluster
 
-### Setup Hive Dependencies
+## Setup Hive Dependencies
+
 We don't need a running Hive to test and develop with. But we will need some CRDs from the project. Most importantly Certman Operator watches for ClusterDeployments and responds to that CR when the status is 'true'.
 
 ```bash
 git clone git@github.com:openshift/hive.git
 oc create -f hive/config/crds
 ```
-### Install CertificateRequest CRD
+
+## Install CertificateRequest CRD
+
 This is the object Certman Operator creates and uses to track certs it creates.
 
 ```bash
 git clone git@github.com:openshift/certman-operator.git
-oc create -f certman-operator/deploy/crds/certman_v1alpha1_certificaterequest_crd.yaml
+oc create -f certman-operator/deploy/crds/certman.managed.openshift.io_certificaterequests.yaml
 ```
-### Make your Namespace
+
+## Make your Namespace
+
 This where all of the Certman Operator objects will live
 
 .If using OpenShift
+
 ```bash
 oc new-project certman-operator
 oc project certman-operator
 ```
 
-### Setup your ConfigMap
-Certman Operator uses a ConfigMap to store options. At the moment, there are 2 items that can be configured using ConfigMap, Let's Encrypt environment, and the default notifcation email.
+## Setup your ConfigMap
+
+Certman Operator uses a ConfigMap to store options. At the moment, there are 2 items that can be configured using ConfigMap, Let's Encrypt environment, and the default notification email.
 
 Example:
+
 ```bash
 oc create configmap certman-operator \
     --from-literal=default_notification_email_address=foo@bar.com
 ```
+
 1. default_notification_email_address - Email address to which Let's Encrypt certificate expiry notifications should be sent.
 
-### Certman Operator Secrets
+## Certman Operator Secrets
+
 Two Secrets are required. One is the AWS credentials that we'll need for working with Route53.
 
 ```bash
@@ -55,7 +67,7 @@ Another Secret is used to store Let's Encrypt account url and keys. we will use 
     --from-file=account-url=account.txt
 ```
 
-### Service Account and RBAC
+## Service Account and RBAC
 
 ```bash
 oc create -f deploy/service_account.yaml
@@ -64,20 +76,22 @@ oc create -f deploy/role_binding.yaml
 oc create -f deploy/operator.yaml
 ```
 
-### Optional: Run Certman Operator
+## Optional: Run Certman Operator
+
 For local developement the easiest way is the use the operator-sdk cli. This will run from the local directory and use local KUBECONFIG environment variable, default `~/.kube/config`
 
 ```bash
-operator-sdk up local
+make run
 ```
-### Optional: Run in cluster
-Or build and upload to a cluster
-```bash
-operator-sdk build <your tag>
-docker push <your tag>
-```
+
+## Optional: Run in cluster
+
+Build the image using [documentation](https://github.com/openshift/boilerplate/blob/master/boilerplate/openshift/golang-osd-operator/app-sre.md) and push to Quay registry in the testing account.
+
 Edit the operator.yaml with your tag. Then deploy to cluster.
+
 ```bash
 oc create -f deploy/operator.yaml
 ```
+
 Happy Developing!


### PR DESCRIPTION
As per [OSD-12979](https://issues.redhat.com/browse/OSD-12979), the certman-operator documentation is to be updated as per the migrated version which would be handled in https://github.com/openshift/certman-operator/pull/225. 

Once migrated version is merged and tested, this PR will track relevant documentation changes post migration. 