### PR TITLE
Correcting code panics due to improper logging usage

### DIFF
--- a/controllers/clusterdeployment/clusterdeployment_controller.go
+++ b/controllers/clusterdeployment/clusterdeployment_controller.go
@@ -111,7 +111,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, request rec
 	// Do not reconcile if the cluster is being relocated
 	for a, v := range cd.Annotations {
 		if a == hiveRelocationAnnotation && strings.Split(v, "/")[1] == hiveRelocationOutgoingValue {
-			reqLogger.Info("Not reconciling: ClusterDeployment %s is relocating", cd.Name)
+			reqLogger.Info(fmt.Sprintf("Not reconciling: ClusterDeployment %s is relocating", cd.Name))
 			return reconcile.Result{}, nil
 		}
 	}

--- a/pkg/clients/aws/route53.go
+++ b/pkg/clients/aws/route53.go
@@ -654,7 +654,7 @@ func getSTSCredentials(reqLogger logr.Logger, client *sts.STS, roleArn string, e
 	// Default duration in seconds of the session token 3600. We need to have the roles policy
 	// changed if we want it to be longer than 3600 seconds
 	var roleSessionDuration int64 = 3600
-	reqLogger.Info("Creating STS credentials for AWS ARN: %s", roleArn)
+	reqLogger.Info(fmt.Sprintf("Creating STS credentials for AWS ARN: %s", roleArn))
 	// Build input for AssumeRole
 	assumeRoleInput := sts.AssumeRoleInput{
 		DurationSeconds: &roleSessionDuration,


### PR DESCRIPTION
PR #225 's bump to the logging dependency seems to have uncovered a case where the logger was being used incorrectly and not supplying a key/value pair as additional arguments, causing a code panic.

I've done a quick pass through the operator looking for occasions where this was happening (only found 2) and corrected them.
