### PR TITLE
Fix the certman operator logic to look up HZ ID by DNSZone.Status.AWS.ZoneID in Hive

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706691034
 
 ENV USER_UID=1001 \
     USER_NAME=certman-operator

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706691034
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706795067
 
 ENV USER_UID=1001 \
     USER_NAME=certman-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706691034
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706795067
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706691034
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -72,3 +72,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - dnszones
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
[OSD-17701](https://issues.redhat.com/browse/OSD-17701) - Fix the certman operator logic to look up HZ ID by DNSZone.Status.AWS.ZoneID in Hive.