### PR TITLE
Fixing Fix the certman operator logic to look up HZ ID by DNSZone.Status.AWS.ZoneID in Hive

### DIFF
--- a/controllers/certificaterequest/issue_certificate.go
+++ b/controllers/certificaterequest/issue_certificate.go
@@ -231,10 +231,10 @@ func (r *CertificateRequestReconciler) FindZoneIDForChallenge(namespace string) 
 	}
 
 	if *dnsZones.Items[0].Status.AWS.ZoneID != "" {
-		return filepath.Base(*dnsZones.Items[0].Status.AWS.ZoneID), nil
-	} else if *dnsZones.Items[0].Status.GCP.ZoneName != "" {
-		return *dnsZones.Items[0].Status.GCP.ZoneName, nil
-	} else {
-		return "", nil
+		return filepath.Base(*dnsZones.Items[0].Status.AWS.ZoneID), nil //the format of that ID is (/hostedzone/<something>) so, we don't care about >/. Here, we only want to grab the stuff after the last
 	}
+	if *dnsZones.Items[0].Status.GCP.ZoneName != "" {
+		return *dnsZones.Items[0].Status.GCP.ZoneName, nil
+	}
+	return "", err
 }

--- a/controllers/certificaterequest/issue_certificate.go
+++ b/controllers/certificaterequest/issue_certificate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package certificaterequest
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -25,15 +26,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/prometheus/client_golang/prometheus"
-	corev1 "k8s.io/api/core/v1"
-
 	certmanv1alpha1 "github.com/openshift/certman-operator/api/v1alpha1"
 	"github.com/openshift/certman-operator/pkg/leclient"
 	"github.com/openshift/certman-operator/pkg/localmetrics"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -110,8 +113,13 @@ func (r *CertificateRequestReconciler) IssueCertificate(reqLogger logr.Logger, c
 		if keyAuthErr != nil {
 			return fmt.Errorf("Could not get authorization key for dns challenge")
 		}
-		fqdn, err := dnsClient.AnswerDNSChallenge(reqLogger, DNS01KeyAuthorization, domain, cr)
 
+		dnsZone, err := r.FindZoneIDForChallenge(cr.Namespace)
+		if err != nil {
+			return err
+		}
+
+		fqdn, err := dnsClient.AnswerDNSChallenge(reqLogger, DNS01KeyAuthorization, domain, cr, dnsZone)
 		if err != nil {
 			return err
 		}
@@ -209,4 +217,24 @@ func (r *CertificateRequestReconciler) IssueCertificate(reqLogger logr.Logger, c
 	}
 
 	return nil
+}
+
+func (r *CertificateRequestReconciler) FindZoneIDForChallenge(namespace string) (dnsZoneID string, err error) {
+	dnsZones := hivev1.DNSZoneList{}
+	err = r.Client.List(context.TODO(), &dnsZones, &client.ListOptions{Namespace: namespace})
+	if err != nil {
+		return "", err
+	}
+
+	if len(dnsZones.Items) != 1 {
+		return "", fmt.Errorf("%d dnsZone objects in a specific namespace found, expected 1 dnsZone", len(dnsZones.Items))
+	}
+
+	if *dnsZones.Items[0].Status.AWS.ZoneID != "" {
+		return filepath.Base(*dnsZones.Items[0].Status.AWS.ZoneID), nil
+	} else if *dnsZones.Items[0].Status.GCP.ZoneName != "" {
+		return *dnsZones.Items[0].Status.GCP.ZoneName, nil
+	} else {
+		return "", nil
+	}
 }

--- a/controllers/certificaterequest/test_helpers.go
+++ b/controllers/certificaterequest/test_helpers.go
@@ -225,7 +225,7 @@ func (f FakeAWSClient) GetDNSName() string {
 	return "Route53"
 }
 
-func (f FakeAWSClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (string, error) {
+func (f FakeAWSClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (string, error) {
 	return testHiveACMEDomain, nil
 }
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -72,3 +72,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - dnszones
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/clients/aws/route53.go
+++ b/pkg/clients/aws/route53.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -66,7 +67,9 @@ var fedrampHostedZoneID = os.Getenv(fedrampHostedZoneIDVariable)
 
 // awsClient implements the Client interface
 type awsClient struct {
-	client route53iface.Route53API
+	client     route53iface.Route53API
+	kubeClient client.Client
+	namespace  string
 }
 
 func (c *awsClient) GetDNSName() string {
@@ -117,60 +120,58 @@ func (c *awsClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken
 		return fqdn, nil
 	}
 
-	hostedZones, err := listAllHostedZones(c.client, &route53.ListHostedZonesInput{})
+	dnsZones := hivev1.DNSZoneList{}
+	err = c.kubeClient.List(context.TODO(), &dnsZones, &client.ListOptions{Namespace: c.namespace})
 	if err != nil {
 		reqLogger.Error(err, err.Error())
 		return "", err
 	}
 
-	baseDomain := cr.Spec.ACMEDNSDomain
-	if !strings.HasSuffix(baseDomain, ".") {
-		baseDomain = baseDomain + "."
+	if len(dnsZones.Items) != 1 {
+		return "", fmt.Errorf("%d dnsZone objects in a specific namespace found, expected 1 dnsZone", len(dnsZones.Items))
+	}
+	dnsZone := dnsZones.Items[0]
+	dnsZoneId := filepath.Base(*dnsZone.Status.AWS.ZoneID)
+
+	zone, err := c.client.GetHostedZone(&route53.GetHostedZoneInput{Id: &dnsZoneId})
+	if err != nil {
+		reqLogger.Error(err, err.Error())
+		return "", err
 	}
 
-	for _, hostedzone := range hostedZones {
-		if strings.EqualFold(baseDomain, *hostedzone.Name) {
-			zone, err := c.client.GetHostedZone(&route53.GetHostedZoneInput{Id: hostedzone.Id})
-			if err != nil {
-				reqLogger.Error(err, err.Error())
-				return "", err
-			}
-
-			// TODO: This duplicate code as AnswerDnsChallenge. Collapse
-			if !*zone.HostedZone.Config.PrivateZone {
-				input := &route53.ChangeResourceRecordSetsInput{
-					ChangeBatch: &route53.ChangeBatch{
-						Changes: []*route53.Change{
-							{
-								Action: aws.String(route53.ChangeActionUpsert),
-								ResourceRecordSet: &route53.ResourceRecordSet{
-									Name: &fqdn,
-									ResourceRecords: []*route53.ResourceRecord{
-										{
-											Value: aws.String(fmt.Sprintf("\"%s\"", acmeChallengeToken)),
-										},
-									},
-									TTL:  aws.Int64(resourceRecordTTL),
-									Type: aws.String(route53.RRTypeTxt),
+	// TODO: This duplicate code as AnswerDnsChallenge. Collapse
+	if !*zone.HostedZone.Config.PrivateZone {
+		input := &route53.ChangeResourceRecordSetsInput{
+			ChangeBatch: &route53.ChangeBatch{
+				Changes: []*route53.Change{
+					{
+						Action: aws.String(route53.ChangeActionUpsert),
+						ResourceRecordSet: &route53.ResourceRecordSet{
+							Name: &fqdn,
+							ResourceRecords: []*route53.ResourceRecord{
+								{
+									Value: aws.String(fmt.Sprintf("\"%s\"", acmeChallengeToken)),
 								},
 							},
+							TTL:  aws.Int64(resourceRecordTTL),
+							Type: aws.String(route53.RRTypeTxt),
 						},
-						Comment: aws.String(""),
 					},
-					HostedZoneId: hostedzone.Id,
-				}
-
-				reqLogger.Info(fmt.Sprintf("updating hosted zone %v", hostedzone.Name))
-
-				result, err := c.client.ChangeResourceRecordSets(input)
-				if err != nil {
-					reqLogger.Error(err, result.GoString(), "fqdn", fqdn)
-					return "", err
-				}
-
-				return fqdn, nil
-			}
+				},
+				Comment: aws.String(""),
+			},
+			HostedZoneId: zone.HostedZone.Id,
 		}
+
+		reqLogger.Info(fmt.Sprintf("updating hosted zone %v", zone.HostedZone.Name))
+
+		result, err := c.client.ChangeResourceRecordSets(input)
+		if err != nil {
+			reqLogger.Error(err, result.GoString(), "fqdn", fqdn)
+			return "", err
+		}
+
+		return fqdn, nil
 	}
 
 	return "", errors.New("unknown error prevented from answering DNS challenge")
@@ -460,7 +461,9 @@ func NewClient(reqLogger logr.Logger, kubeClient client.Client, secretName, name
 		}
 
 		c := &awsClient{
-			client: route53.New(s),
+			kubeClient: kubeClient,
+			client:     route53.New(s),
+			namespace:  namespace,
 		}
 
 		return c, err
@@ -599,7 +602,9 @@ func NewClient(reqLogger logr.Logger, kubeClient client.Client, secretName, name
 		}
 
 		c := &awsClient{
-			client: route53.New(cs),
+			kubeClient: kubeClient,
+			client:     route53.New(cs),
+			namespace:  namespace,
 		}
 
 		return c, err
@@ -644,9 +649,10 @@ func NewClient(reqLogger logr.Logger, kubeClient client.Client, secretName, name
 	}
 
 	c := &awsClient{
-		client: route53.New(s),
+		kubeClient: kubeClient,
+		client:     route53.New(s),
+		namespace:  namespace,
 	}
-
 	return c, err
 }
 

--- a/pkg/clients/aws/route53_test.go
+++ b/pkg/clients/aws/route53_test.go
@@ -111,12 +111,6 @@ func TestAnswerDNSChallenge(t *testing.T) {
 			ExpectedFQDN: fmt.Sprintf("%s.%s", cTypes.AcmeChallengeSubDomain, testHiveACMEDomain),
 			ExpectError:  false,
 		},
-		{
-			Name:        "zero dnszones",
-			TestClient:  &mockroute53.MockRoute53Client{ZoneCount: 1},
-			Namespace:   "ns-with-no-dnszones",
-			ExpectError: true,
-		},
 	}
 
 	for _, test := range tests {
@@ -125,7 +119,7 @@ func TestAnswerDNSChallenge(t *testing.T) {
 				client: test.TestClient,
 			}
 
-			actualFQDN, err := r53.AnswerDNSChallenge(logr.Discard(), "fakechallengetoken", certRequest.Spec.ACMEDNSDomain, certRequest, testHiveACMEDomain)
+			actualFQDN, err := r53.AnswerDNSChallenge(logr.Discard(), "fakechallengetoken", certRequest.Spec.ACMEDNSDomain, certRequest, "id0")
 			if test.ExpectError == (err == nil) {
 				t.Errorf("AnswerDNSChallenge() %s: ExpectError: %t, actual error: %s\n", test.Name, test.ExpectError, err)
 			}

--- a/pkg/clients/aws/route53_test.go
+++ b/pkg/clients/aws/route53_test.go
@@ -122,12 +122,10 @@ func TestAnswerDNSChallenge(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			r53 := &awsClient{
-				client:     test.TestClient,
-				kubeClient: setUpTestClient(t),
-				namespace:  test.Namespace,
+				client: test.TestClient,
 			}
 
-			actualFQDN, err := r53.AnswerDNSChallenge(logr.Discard(), "fakechallengetoken", certRequest.Spec.ACMEDNSDomain, certRequest)
+			actualFQDN, err := r53.AnswerDNSChallenge(logr.Discard(), "fakechallengetoken", certRequest.Spec.ACMEDNSDomain, certRequest, testHiveACMEDomain)
 			if test.ExpectError == (err == nil) {
 				t.Errorf("AnswerDNSChallenge() %s: ExpectError: %t, actual error: %s\n", test.Name, test.ExpectError, err)
 			}

--- a/pkg/clients/azure/dns.go
+++ b/pkg/clients/azure/dns.go
@@ -85,7 +85,7 @@ func (c *azureClient) GetDNSName() string {
 	return "DNS Zone"
 }
 
-func (c *azureClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (fqdn string, err error) {
+func (c *azureClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {
 	zone, err := c.zonesClient.Get(context.TODO(), c.resourceGroupName, cr.Spec.ACMEDNSDomain)
 	if err != nil {
 		reqLogger.Error(err, fmt.Sprintf("Error getting dns zone %v", cr.Spec.ACMEDNSDomain))

--- a/pkg/clients/client.go
+++ b/pkg/clients/client.go
@@ -22,7 +22,7 @@ var (
 type Client interface {
 	// Client methods
 	GetDNSName() string
-	AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (string, error)
+	AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (string, error)
 	ValidateDNSWriteAccess(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) (bool, error)
 	DeleteAcmeChallengeResourceRecords(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) error
 }

--- a/pkg/clients/gcp/dns.go
+++ b/pkg/clients/gcp/dns.go
@@ -47,7 +47,7 @@ func (c *gcpClient) GetDNSName() string {
 	return "Cloud DNS"
 }
 
-func (c *gcpClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (fqdn string, err error) {
+func (c *gcpClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {
 	fqdn = fmt.Sprintf("%s.%s", cTypes.AcmeChallengeSubDomain, domain)
 	reqLogger.Info(fmt.Sprintf("fqdn acme challenge domain is %v", fqdn))
 

--- a/pkg/clients/mock/mock.go
+++ b/pkg/clients/mock/mock.go
@@ -42,7 +42,7 @@ func (c *MockClient) GetDNSName() string {
 	return "Mock"
 }
 
-func (c *MockClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (fqdn string, err error) {
+func (c *MockClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {
 	fqdn = c.AnswerDNSChallengeFQDN
 
 	if c.AnswerDNSChallengeErrorString != "" {

--- a/pkg/clients/mock/mock_test.go
+++ b/pkg/clients/mock/mock_test.go
@@ -83,7 +83,7 @@ func TestAnswerDNSChallenge(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			actualFQDN, err := test.TestClient.AnswerDNSChallenge(logr.Discard(), "ignored", "irrelevant", &certmanv1alpha1.CertificateRequest{})
+			actualFQDN, err := test.TestClient.AnswerDNSChallenge(logr.Discard(), "ignored", "irrelevant", &certmanv1alpha1.CertificateRequest{}, "testvalue")
 			if err != nil && err.Error() != test.ExpectedAnswerDNSChallengeErrorString {
 				t.Errorf("AnswerDNSChallenge() %s: expected error \"%s\", got error \"%s\"\n", test.Name, test.ExpectedAnswerDNSChallengeErrorString, err.Error())
 			}


### PR DESCRIPTION
[OSD-17701](https://issues.redhat.com/browse/OSD-17701) - Fix the certman operator logic to look up HZ ID by DNSZone.Status.AWS.ZoneID in Hive.