### PR TITLE
Fixing Fix the certman operator logic to look up HZ ID by DNSZone.Status.AWS.ZoneID in Hive 

### DIFF
--- a/controllers/certificaterequest/test_helpers.go
+++ b/controllers/certificaterequest/test_helpers.go
@@ -225,7 +225,7 @@ func (f FakeAWSClient) GetDNSName() string {
 	return "Route53"
 }
 
-func (f FakeAWSClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (string, error) {
+func (f FakeAWSClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (string, error) {
 	return testHiveACMEDomain, nil
 }
 
@@ -250,6 +250,7 @@ func setUpTestClient(t *testing.T, objects []runtime.Object) client.Client {
 	s := scheme.Scheme
 	s.AddKnownTypes(certmanv1alpha1.GroupVersion, certRequest)
 	s.AddKnownTypes(hivev1.SchemeGroupVersion, clusterDeploymentComplete)
-
+	s.AddKnownTypes(hivev1.SchemeGroupVersion, &hivev1.DNSZoneList{})
+	s.AddKnownTypes(hivev1.SchemeGroupVersion, &hivev1.DNSZone{})
 	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
 }

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -72,3 +72,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - dnszones
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/clients/aws/route53_test.go
+++ b/pkg/clients/aws/route53_test.go
@@ -98,6 +98,7 @@ func TestAnswerDNSChallenge(t *testing.T) {
 	tests := []struct {
 		Name         string
 		TestClient   route53iface.Route53API
+		Namespace    string
 		ExpectedFQDN string
 		ExpectError  bool
 	}{
@@ -106,6 +107,7 @@ func TestAnswerDNSChallenge(t *testing.T) {
 			TestClient: &mockroute53.MockRoute53Client{
 				ZoneCount: 1,
 			},
+			Namespace:    testHiveNamespace,
 			ExpectedFQDN: fmt.Sprintf("%s.%s", cTypes.AcmeChallengeSubDomain, testHiveACMEDomain),
 			ExpectError:  false,
 		},
@@ -117,7 +119,7 @@ func TestAnswerDNSChallenge(t *testing.T) {
 				client: test.TestClient,
 			}
 
-			actualFQDN, err := r53.AnswerDNSChallenge(logr.Discard(), "fakechallengetoken", certRequest.Spec.ACMEDNSDomain, certRequest)
+			actualFQDN, err := r53.AnswerDNSChallenge(logr.Discard(), "fakechallengetoken", certRequest.Spec.ACMEDNSDomain, certRequest, "id0")
 			if test.ExpectError == (err == nil) {
 				t.Errorf("AnswerDNSChallenge() %s: ExpectError: %t, actual error: %s\n", test.Name, test.ExpectError, err)
 			}
@@ -198,6 +200,7 @@ func TestDeleteAcmeChallengeResourceRecords(t *testing.T) {
 }
 
 // helpers
+var testHiveName = "doesntexist"
 var testHiveNamespace = "uhc-doesntexist-123456"
 var testHiveCertificateRequestName = "clustername-1313-0-primary-cert-bundle"
 var testHiveCertSecretName = "primary-cert-bundle-secret" //#nosec - G101: Potential hardcoded credentials
@@ -205,6 +208,7 @@ var testHiveACMEDomain = "name0"
 var testHiveAWSSecretName = "aws"
 var testHiveAWSRegion = "not-relevant-1"
 var testHiveClusterDeploymentName = "test-cluster"
+var testDnsZoneID = "hostedzone/id0"
 
 var certRequest = &certmanv1alpha1.CertificateRequest{
 	ObjectMeta: metav1.ObjectMeta{
@@ -247,6 +251,19 @@ var awsSecret = &v1.Secret{
 	},
 }
 
+var testDnsstatus = &hivev1.AWSDNSZoneStatus{
+	ZoneID: &testDnsZoneID,
+}
+
+var testDnsZone = &hivev1.DNSZone{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      testHiveName,
+		Namespace: testHiveNamespace,
+	},
+	Status: hivev1.DNSZoneStatus{
+		AWS: testDnsstatus,
+	},
+}
 var testClusterDeployment = &hivev1.ClusterDeployment{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: testHiveNamespace,
@@ -262,7 +279,6 @@ func setUpEmptyTestClient(t *testing.T) (testClient client.Client) {
 
 	// aws is not an existing secret
 	objects := []runtime.Object{certRequest}
-
 	testClient = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
 	return
 }
@@ -272,10 +288,12 @@ func setUpTestClient(t *testing.T) (testClient client.Client) {
 
 	s := scheme.Scheme
 	s.AddKnownTypes(certmanv1alpha1.GroupVersion, certRequest)
-	s.AddKnownTypes(hivev1.SchemeGroupVersion, testClusterDeployment)
+	if err := hivev1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
 
 	// aws is not an existing secret
-	objects := []runtime.Object{certRequest, awsSecret, testClusterDeployment}
+	objects := []runtime.Object{certRequest, awsSecret, testClusterDeployment, testDnsZone}
 
 	testClient = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
 	return

--- a/pkg/clients/azure/dns.go
+++ b/pkg/clients/azure/dns.go
@@ -84,8 +84,7 @@ func (c *azureClient) generateTxtRecordName(domain string, rootDomain string) st
 func (c *azureClient) GetDNSName() string {
 	return "DNS Zone"
 }
-
-func (c *azureClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (fqdn string, err error) {
+func (c *azureClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {
 	zone, err := c.zonesClient.Get(context.TODO(), c.resourceGroupName, cr.Spec.ACMEDNSDomain)
 	if err != nil {
 		reqLogger.Error(err, fmt.Sprintf("Error getting dns zone %v", cr.Spec.ACMEDNSDomain))

--- a/pkg/clients/client.go
+++ b/pkg/clients/client.go
@@ -22,7 +22,7 @@ var (
 type Client interface {
 	// Client methods
 	GetDNSName() string
-	AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (string, error)
+	AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (string, error)
 	ValidateDNSWriteAccess(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) (bool, error)
 	DeleteAcmeChallengeResourceRecords(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) error
 }

--- a/pkg/clients/gcp/dns.go
+++ b/pkg/clients/gcp/dns.go
@@ -47,7 +47,7 @@ func (c *gcpClient) GetDNSName() string {
 	return "Cloud DNS"
 }
 
-func (c *gcpClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (fqdn string, err error) {
+func (c *gcpClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {
 	fqdn = fmt.Sprintf("%s.%s", cTypes.AcmeChallengeSubDomain, domain)
 	reqLogger.Info(fmt.Sprintf("fqdn acme challenge domain is %v", fqdn))
 

--- a/pkg/clients/mock/mock.go
+++ b/pkg/clients/mock/mock.go
@@ -42,7 +42,7 @@ func (c *MockClient) GetDNSName() string {
 	return "Mock"
 }
 
-func (c *MockClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest) (fqdn string, err error) {
+func (c *MockClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {
 	fqdn = c.AnswerDNSChallengeFQDN
 
 	if c.AnswerDNSChallengeErrorString != "" {

--- a/pkg/clients/mock/mock_test.go
+++ b/pkg/clients/mock/mock_test.go
@@ -83,7 +83,7 @@ func TestAnswerDNSChallenge(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			actualFQDN, err := test.TestClient.AnswerDNSChallenge(logr.Discard(), "ignored", "irrelevant", &certmanv1alpha1.CertificateRequest{})
+			actualFQDN, err := test.TestClient.AnswerDNSChallenge(logr.Discard(), "ignored", "irrelevant", &certmanv1alpha1.CertificateRequest{}, "testvalue")
 			if err != nil && err.Error() != test.ExpectedAnswerDNSChallengeErrorString {
 				t.Errorf("AnswerDNSChallenge() %s: expected error \"%s\", got error \"%s\"\n", test.Name, test.ExpectedAnswerDNSChallengeErrorString, err.Error())
 			}


### PR DESCRIPTION
Fixing #261 as part of [OSD-17701](https://issues.redhat.com/browse/OSD-17701). Fix the certman operator logic to look up HZ ID by DNSZone.Status.AWS.ZoneID in Hive.