### PR TITLE
updates dns zone logic for DNS challenge to account for FedRAMP

### DIFF
--- a/controllers/certificaterequest/issue_certificate.go
+++ b/controllers/certificaterequest/issue_certificate.go
@@ -114,14 +114,23 @@ func (r *CertificateRequestReconciler) IssueCertificate(reqLogger logr.Logger, c
 		if keyAuthErr != nil {
 			return fmt.Errorf("Could not get authorization key for dns challenge")
 		}
-		dnsZone, err := r.FindZoneIDForChallenge(cr.Namespace)
-		if err != nil {
-			return err
-		}
 
-		fqdn, err := dnsClient.AnswerDNSChallenge(reqLogger, DNS01KeyAuthorization, domain, cr, dnsZone)
-		if err != nil {
-			return err
+		var fqdn string
+		if !fedramp {
+			dnsZone, err := r.FindZoneIDForChallenge(cr.Namespace)
+			if err != nil {
+				return err
+			}
+
+			fqdn, err = dnsClient.AnswerDNSChallenge(reqLogger, DNS01KeyAuthorization, domain, cr, dnsZone)
+			if err != nil {
+				return err
+			}
+		} else {
+			fqdn, err = dnsClient.AnswerDNSChallenge(reqLogger, DNS01KeyAuthorization, domain, cr, "")
+			if err != nil {
+				return err
+			}
 		}
 
 		// don't try verifying DNS while in testing

--- a/pkg/clients/aws/route53.go
+++ b/pkg/clients/aws/route53.go
@@ -104,8 +104,9 @@ func (c *awsClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken
 			return "", err
 		}
 		input.HostedZoneId = zone.HostedZone.Id
+	} else {
+		input.HostedZoneId = &dnsZone
 	}
-	input.HostedZoneId = &dnsZone
 	result, err := c.client.ChangeResourceRecordSets(input)
 	if err != nil {
 		reqLogger.Error(err, result.GoString(), "fqdn", fqdn)


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSD-24260
* FedRAMP does not use `DNSZone` CR's nor managed DNS from Hive, the FindZoneID call fails in FedRAMP due to that
* Updates logic to ensure FedRAMP is accounted for