### PR TITLE
Refactor certman-operator HostedZone Changes

### DIFF
--- a/controllers/certificaterequest/test_helpers.go
+++ b/controllers/certificaterequest/test_helpers.go
@@ -37,13 +37,13 @@ import (
 )
 
 // helpers
-
 var testHiveNamespace = "uhc-doesntexist-123456"
 var testHiveClusterDeploymentName = "clustername-1313"
 var testHiveClusterDeploymentUID = types.UID("some-fake-uid")
 var testHiveCertificateRequestName = fmt.Sprintf("%s-primary-cert-bundle", testHiveClusterDeploymentName)
 var testHiveSecretName = "primary-cert-bundle-secret" //#nosec - G101: Potential hardcoded credentials
 var testHiveACMEDomain = "not.a.valid.tld"
+var testHiveFedRampZoneID = "Z10091REDACTEDW6I"
 
 var clusterDeploymentIncoming = &hivev1.ClusterDeployment{
 	TypeMeta: metav1.TypeMeta{
@@ -223,6 +223,10 @@ type FakeAWSClient struct {
 
 func (f FakeAWSClient) GetDNSName() string {
 	return "Route53"
+}
+
+func (f FakeAWSClient) GetFedrampHostedZoneIDPath(fedrampHostedZoneID string) (string, error) {
+	return testHiveFedRampZoneID, nil
 }
 
 func (f FakeAWSClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (string, error) {

--- a/pkg/clients/aws/mockroute53/mockroute53.go
+++ b/pkg/clients/aws/mockroute53/mockroute53.go
@@ -16,6 +16,15 @@ type MockRoute53Client struct {
 	ZoneCount int
 }
 
+func (m *MockRoute53Client) GetFedrampHostedZoneIDPath(fedrampHostedZoneID string) (string, error) {
+	zone := &route53.GetHostedZoneOutput{
+		HostedZone: &route53.HostedZone{
+			Id: &fedrampHostedZoneID,
+		},
+	}
+	return *zone.HostedZone.Id, nil
+}
+
 func (m *MockRoute53Client) ListHostedZones(lhzi *route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error) {
 	hostedZones := []*route53.HostedZone{}
 

--- a/pkg/clients/aws/route53_test.go
+++ b/pkg/clients/aws/route53_test.go
@@ -54,6 +54,44 @@ func TestGetDNSName(t *testing.T) {
 	})
 }
 
+func TestGetFedrampHostedZoneIDPath(t *testing.T) {
+	tests := []struct {
+		testFedRampHostedZoneID     string
+		ExpectError                 bool
+		Name                        string
+		ExpectedFedRampHostedZoneID string
+		fedramp                     bool
+	}{
+		{
+			Name:                        "returns a FedRamp Hosted Zone ID",
+			testFedRampHostedZoneID:     "Z10091REDACTEDW6I",
+			ExpectError:                 false,
+			ExpectedFedRampHostedZoneID: "Z10091REDACTEDW6I",
+			fedramp:                     true,
+		},
+	}
+	for _, test := range tests {
+		t.Run("returns the client type", func(t *testing.T) {
+			// r53AWS := &awsClient{
+			// 	client: &mockroute53.MockRoute53Client{},
+			// }
+			r53 := &mockroute53.MockRoute53Client{}
+			FedrampHostedZoneIDErrorString, err := r53.GetFedrampHostedZoneIDPath(test.testFedRampHostedZoneID)
+
+			if FedrampHostedZoneIDErrorString != test.ExpectedFedRampHostedZoneID {
+				t.Errorf("FedrampHostedZoneIDErrorString(): got %s, expected %s\n", FedrampHostedZoneIDErrorString, test.ExpectedFedRampHostedZoneID)
+			}
+			if FedrampHostedZoneIDErrorString == "" {
+				t.Errorf("FedrampHostedZoneIDErrorString is empty: %q", err)
+			}
+			if err != nil {
+				t.Errorf("unexpected error when creating returning the FedrampHostedZoneID: %q", err)
+			}
+
+		})
+	}
+}
+
 func TestNewClient(t *testing.T) {
 	t.Run("returns an error if the credentials aren't set", func(t *testing.T) {
 		testClient := setUpEmptyTestClient(t)

--- a/pkg/clients/azure/dns.go
+++ b/pkg/clients/azure/dns.go
@@ -84,6 +84,11 @@ func (c *azureClient) generateTxtRecordName(domain string, rootDomain string) st
 func (c *azureClient) GetDNSName() string {
 	return "DNS Zone"
 }
+
+func (c *azureClient) GetFedrampHostedZoneIDPath(_ string) (string, error) {
+	return "", fmt.Errorf("FedRamp is not supported by Azure")
+}
+
 func (c *azureClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {
 	zone, err := c.zonesClient.Get(context.TODO(), c.resourceGroupName, cr.Spec.ACMEDNSDomain)
 	if err != nil {

--- a/pkg/clients/client.go
+++ b/pkg/clients/client.go
@@ -21,6 +21,7 @@ var (
 // Client is a wrapper object for actual AWS SDK clients to allow for easier testing.
 type Client interface {
 	// Client methods
+	GetFedrampHostedZoneIDPath(fedrampHostedZoneID string) (string, error)
 	GetDNSName() string
 	AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (string, error)
 	ValidateDNSWriteAccess(reqLogger logr.Logger, cr *certmanv1alpha1.CertificateRequest) (bool, error)

--- a/pkg/clients/gcp/dns.go
+++ b/pkg/clients/gcp/dns.go
@@ -47,6 +47,10 @@ func (c *gcpClient) GetDNSName() string {
 	return "Cloud DNS"
 }
 
+func (c *gcpClient) GetFedrampHostedZoneIDPath(_ string) (string, error) {
+	return "", fmt.Errorf("FedRamp is not supported by GCP")
+}
+
 func (c *gcpClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {
 	fqdn = fmt.Sprintf("%s.%s", cTypes.AcmeChallengeSubDomain, domain)
 	reqLogger.Info(fmt.Sprintf("fqdn acme challenge domain is %v", fqdn))

--- a/pkg/clients/mock/mock.go
+++ b/pkg/clients/mock/mock.go
@@ -9,9 +9,10 @@ import (
 )
 
 type MockClient struct {
-	AnswerDNSChallengeFQDN        string
-	AnswerDNSChallengeErrorString string
-
+	AnswerDNSChallengeFQDN            string
+	AnswerDNSChallengeErrorString     string
+	FedrampHostedZoneID               string
+	FedrampHostedZoneIDErrorString    string
 	ValidateDNSWriteAccessBool        bool
 	ValidateDNSWriteAccessErrorString string
 
@@ -19,9 +20,9 @@ type MockClient struct {
 }
 
 type MockClientOptions struct {
-	AnswerDNSChallengeFQDN        string
-	AnswerDNSChallengeErrorString string
-
+	AnswerDNSChallengeFQDN            string
+	AnswerDNSChallengeErrorString     string
+	FedrampHostedZoneID               string
 	ValidateDNSWriteAccessBool        bool
 	ValidateDNSWriteAccessErrorString string
 
@@ -30,6 +31,7 @@ type MockClientOptions struct {
 
 func NewMockClient(opts *MockClientOptions) (c *MockClient) {
 	c = &MockClient{}
+	c.FedrampHostedZoneID = opts.FedrampHostedZoneID
 	c.AnswerDNSChallengeFQDN = opts.AnswerDNSChallengeFQDN
 	c.AnswerDNSChallengeErrorString = opts.AnswerDNSChallengeErrorString
 	c.ValidateDNSWriteAccessBool = opts.ValidateDNSWriteAccessBool
@@ -40,6 +42,15 @@ func NewMockClient(opts *MockClientOptions) (c *MockClient) {
 
 func (c *MockClient) GetDNSName() string {
 	return "Mock"
+}
+
+func (c *MockClient) GetFedrampHostedZoneIDPath(fedrampHostedZoneID string) (string, error) {
+	zoneID := c.FedrampHostedZoneID
+	var err error
+	if c.FedrampHostedZoneIDErrorString != "" {
+		err = errors.New(c.FedrampHostedZoneIDErrorString)
+	}
+	return zoneID, err
 }
 
 func (c *MockClient) AnswerDNSChallenge(reqLogger logr.Logger, acmeChallengeToken string, domain string, cr *certmanv1alpha1.CertificateRequest, dnsZone string) (fqdn string, err error) {


### PR DESCRIPTION
Refactor certman-operator HostedZone Changes where we I refactor the FedRAMP logic out of the aws/route53.go file and into the r.FindZoneIDForChallenge() function  as part of [OSD-24304](https://issues.redhat.com//browse/OSD-24304)