### PR TITLE
Removing decomissioned certificates from the metrics

### DIFF
--- a/pkg/localmetrics/localmetrics_test.go
+++ b/pkg/localmetrics/localmetrics_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestUpdateCertValidDuration(t *testing.T) {
 	// Create a test certificate
-	createTestCert := func(notAfter time.Time) *x509.Certificate {
+	createTestCert := func(notAfter time.Time, commonName string) *x509.Certificate {
 		return &x509.Certificate{
 			NotAfter: notAfter,
-			Subject:  pkix.Name{CommonName: "test.example.com"},
+			Subject:  pkix.Name{CommonName: commonName},
 		}
 	}
 
@@ -23,36 +23,52 @@ func TestUpdateCertValidDuration(t *testing.T) {
 	MetricCertValidDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "certman_operator_certificate_valid_duration_days",
 		Help: "The number of days for which the certificate remains valid",
-	}, []string{"cn"})
+	}, []string{"cn", "cluster"})
 
 	tests := []struct {
-		name     string
-		cert     *x509.Certificate
-		expected float64
+		name        string
+		cert        *x509.Certificate
+		clusterName string
+		expected    float64
 	}{
 		{
-			name:     "Cert expired yesterday",
-			cert:     createTestCert(time.Now().Add(-24 * time.Hour)),
-			expected: 0,
+			name:        "Cert expired yesterday",
+			cert:        createTestCert(time.Now().Add(-24*time.Hour), "test.example.com"),
+			clusterName: "test-cluster",
+			expected:    0,
 		},
 		{
-			name:     "Cert expires tomorrow",
-			cert:     createTestCert(time.Now().Add(24 * time.Hour)),
-			expected: 1,
+			name:        "Cert expires tomorrow",
+			cert:        createTestCert(time.Now().Add(24*time.Hour), "test.example.com"),
+			clusterName: "test-cluster",
+			expected:    1,
 		},
 		{
-			name:     "Cert expires in 30 days",
-			cert:     createTestCert(time.Now().Add(30 * 24 * time.Hour)),
-			expected: 30,
+			name:        "Cert expires in 30 days",
+			cert:        createTestCert(time.Now().Add(30*24*time.Hour), "test.example.com"),
+			clusterName: "test-cluster",
+			expected:    30,
+		},
+		{
+			name:        "Nil certificate",
+			cert:        nil,
+			clusterName: "test-cluster",
+			expected:    0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Pass the third argument, the fallback common name
-			UpdateCertValidDuration(tt.cert, time.Now(), tt.cert.Subject.CommonName)
+			UpdateCertValidDuration(tt.cert, time.Now(), tt.clusterName)
 
-			metric, err := MetricCertValidDuration.GetMetricWithLabelValues(tt.cert.Subject.CommonName)
+			var cn string
+			if tt.cert != nil {
+				cn = tt.cert.Subject.CommonName
+			} else {
+				cn = tt.clusterName
+			}
+
+			metric, err := MetricCertValidDuration.GetMetricWithLabelValues(cn, tt.clusterName)
 			if err != nil {
 				t.Fatalf("Error getting metric: %v", err)
 			}


### PR DESCRIPTION
As part of the bug [OSD-14653](https://issues.redhat.com/browse/OSD-14653), we will be trying to delete the decom certs from the UpdateCertValidDuration metrics.

Currently, as shown in this link (https://grafana.app-sre.devshift.net/explore?schemaVersion=1&panes=%7B%22x7t%22:%7B%22datasource%22:%22P3D303D298AFF784A%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22certman_operator_certificate_valid_duration_days%20%3C%2045%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P3D303D298AFF784A%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22,%22useBackend%22:false,%22disableTextWrap%22:false,%22fullMetaSearch%22:false,%22includeNullMetadata%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1) it is showing us all the certificates which are decommissioned 

Also, Removing those dummy metrics we added to find a bug about missing clusters and its certificate