### PR TITLE
Add metrics config back to controller opts

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,12 +148,12 @@ func main() {
 	options := manager.Options{
 		// Namespace: namespace,
 		Scheme: scheme,
-		// Port:                   9443,
+		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "529d7a9e.managed.openshift.io",
 		// Disable controller-runtime metrics serving
-		// MetricsBindAddress: "0",
+		MetricsBindAddress: "0",
 	}
 	// cacheOptions := cache.Options{
 	// 	Scheme: options.Scheme,


### PR DESCRIPTION
This restores the metrics bind address and serving port removed in a
previous commit.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
