### PR TITLE
OSD-26042 - Return when certificaterequest secret is not found

### DIFF
--- a/controllers/certificaterequest/certificaterequest_controller.go
+++ b/controllers/certificaterequest/certificaterequest_controller.go
@@ -414,6 +414,7 @@ func (r *CertificateRequestReconciler) revokeCertificateAndDeleteSecret(reqLogge
 	}
 	if !exists {
 		reqLogger.Info("Secret does not exist")
+		return nil
 	}
 
 	error := r.RevokeCertificate(reqLogger, cr)


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-26042

---

Certman-operator should not attempt to revoke certificates when the requisite secret does not exist. These changes slightly modify the logic from #293 to match prior behavior.