### PR TITLE
OSD-26057: Better logging for assumeRole errors

### DIFF
--- a/pkg/clients/aws/route53.go
+++ b/pkg/clients/aws/route53.go
@@ -628,11 +628,15 @@ func getSTSCredentials(reqLogger logr.Logger, client *sts.STS, roleArn string, e
 
 			default:
 				// Handle other AWS errors as needed
-				reqLogger.Error(aerr, "unhandled AWS error")
+				reqLogger.Error(aerr, "unhandled AWS error. This typically means there is an issue with IAM roles for the cluster. Check if the cluster is in limited support.")
 			}
 		}
 		// If we still have retries, log the failure and try again
-		reqLogger.Info(fmt.Sprintf("failed to assumeRole (attempt %d out of %d)", i, assumeRolePollingRetries))
+		if i == 1 || i%25 == 0 {
+			reqLogger.Info(fmt.Sprintf("failed to assumeRole (attempt %d out of %d). Subsequent attempts will be looged at Verbosity 1 instead of 0 to reduce noise.", i, assumeRolePollingRetries))
+		} else {
+			reqLogger.V(1).Info(fmt.Sprintf("failed to assumeRole (attempt %d out of %d)", i, assumeRolePollingRetries))
+		}
 	}
 	return assumeRoleOutput, nil
 }


### PR DESCRIPTION
We were flooding logs with "Unhandled AWS error"
I made it so only the first, 25th, 50th, 75th, and 100th retry is logged to the standard log level. The rest are logged at a higher level. The verbiage is different, but it's essentially the difference between info and debug logs.

This is tracked in [OSD-26057](https://issues.redhat.com//browse/OSD-26057)