### PR TITLE
OSD-26034: Update owners file to properly reflect current team rocket.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,8 +2,10 @@ reviewers:
 - aliceh
 - anispate
 - clcollins
-- iamkirkbater
+- mhodesty
 - tnierman
+- nephomaniac 
+- hbhushan3
 approvers:
 - clcollins
 - dustman9000


### PR DESCRIPTION
Added all of team rocket to the reviewers and removed Kirk from Reviewers.
Approvers are unchanged.