### PR TITLE
Add FLs and TLs as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,3 +10,5 @@ approvers:
 - clcollins
 - dustman9000
 - iamkirkbater
+- srep-functional-leads
+- srep-team-leads


### PR DESCRIPTION
Make FLs and TLs approvers for cases where standard approvers aren't suitable/are hard to reach.

Ref [OSD-25197](https://issues.redhat.com//browse/OSD-25197)