### PR TITLE
Add the certman_operator_cluster_in_limited_support metrics

### DIFF
--- a/controllers/certificaterequest/certificaterequest_controller.go
+++ b/controllers/certificaterequest/certificaterequest_controller.go
@@ -451,7 +451,6 @@ func (r *CertificateRequestReconciler) UpdateCertValidDuration(cr *certmanv1alph
 	return localmetrics.UpdateCertValidDuration(certificate, cr.Name, cr.Namespace)
 }
 
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *CertificateRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
As part of OSD-14653, add the LimitedSupport metrics so, we can filter out the clusters which are LS