### PR TITLE
OSD-28159 - Enable OLM Skip Range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 const (
-	OperatorName      string = "certman-operator"
-	OperatorNamespace string = "certman-operator"
+	OperatorName       string = "certman-operator"
+	OperatorNamespace  string = "certman-operator"
+	EnableOLMSkipRange        = "true"
 )

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -34,7 +34,8 @@ objects:
     name: certman-operator-og
   spec:
     targetNamespaces:
-    - certman-operator
+      - certman-operator
+    upgradeStrategy: TechPreviewUnsafeFailForward
 
 - apiVersion: operators.coreos.com/v1alpha1
   kind: Subscription


### PR DESCRIPTION
Configure boilerplate to generate an OLM bundle with a skip range pointing to the latest version. This will allow OLM to upgrade past broken replaces chains in which versions get abadoned without a path forward. The new OLM bundle will contain a single version, referencing the latest build with a skipRange to the version. Part of [OSD-28159](https://issues.redhat.com//browse/OSD-28159) ticket.