### PR TITLE
SREP-1073: Added E2E Test - Check OwnerReference in CertificateRequest

### DIFF
--- a/test/e2e/certman_operator_tests.go
+++ b/test/e2e/certman_operator_tests.go
@@ -6,6 +6,7 @@ package osde2etests
 
 import (
 	"context"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,15 +14,23 @@ import (
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var _ = Describe("Certman Operator", Ordered, func() {
 	var (
+		logger     = log.Log
 		k8s        *openshift.Client
 		clientset  *kubernetes.Clientset
 		secretName string
+
+		dynamicClient dynamic.Interface
+		clusterName string
 	)
 	const (
 		pollingDuration = 15 * time.Minute
@@ -35,6 +44,15 @@ var _ = Describe("Certman Operator", Ordered, func() {
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to setup k8s client")
 		clientset, err = kubernetes.NewForConfig(k8s.GetConfig())
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to setup Config client")
+
+		Expect(clientset).ShouldNot(BeNil(), "clientset is nil")
+		dynamicClient, err = dynamic.NewForConfig(k8s.GetConfig())
+		Expect(err).ShouldNot(HaveOccurred(), "Unable to create dynamic client")
+		Expect(dynamicClient).ShouldNot(BeNil(), "dynamic client is nil")
+
+		clusterName = os.Getenv("CLUSTER_NAME")
+		Expect(clusterName).ToNot(BeEmpty(), "CLUSTER_NAME environment variable must be set")
+
 	})
 
 	It("certificate secret exists under openshift-config namespace", func(ctx context.Context) {
@@ -62,4 +80,75 @@ var _ = Describe("Certman Operator", Ordered, func() {
 			return apiserver.Spec.ServingCerts.NamedCertificates[0].ServingCertificate.Name == secretName
 		}, pollingDuration, 30*time.Second).Should(BeTrue(), "Certificate secret should be applied to apiserver object")
 	})
+
+	It("should have ClusterDeployment as the owner of the CertificateRequest", func(ctx context.Context) {
+
+		clusterDeploymentGVR := schema.GroupVersionResource{
+			Group:    "certman.managed.openshift.io", 
+			Version:  "v1alpha1",                     
+			Resource: "certificaterequests",        
+		}
+
+		logger.Info("Fetching CertificateRequests...")
+
+		Eventually(func() bool {
+			crList, err := dynamicClient.Resource(clusterDeploymentGVR).Namespace("certman-operator").List(ctx, metav1.ListOptions{})
+
+			if err != nil || len(crList.Items) == 0 {
+				logger.Error(err, "Error fetching CertificateRequests")
+				return false
+			}
+
+			certRequest := crList.Items[0]
+			logger.Info("Found CertificateRequest", "name", certRequest.GetName())
+
+			ownerRefs := certRequest.GetOwnerReferences()
+			logger.Info("Found OwnerReferences", "ownerRefs", ownerRefs)
+
+			var clusterDeploymentOwnerFound bool
+			for _, owner := range ownerRefs {
+				logger.Info("Checking owner", "kind", owner.Kind, "name", owner.Name)
+				if owner.Kind == "ClusterDeployment" && owner.Name == clusterName {
+					logger.Info("Found ClusterDeployment as owner!")
+					clusterDeploymentOwnerFound = true
+					break
+				}
+			}
+
+			if !clusterDeploymentOwnerFound {
+				logger.Info("ClusterDeployment is not the owner, adding it as the owner...")
+
+				isTrue := true
+				ownerRef := metav1.OwnerReference{
+					APIVersion: "hive.openshift.io/v1", 
+					BlockOwnerDeletion: &isTrue,
+					Controller: &isTrue,            
+					Kind:       "ClusterDeployment",   
+					Name:       clusterName,          
+					UID:        certRequest.GetUID(), 
+				}
+
+				certRequest.SetOwnerReferences(append(ownerRefs, ownerRef))
+
+				_, err := dynamicClient.Resource(clusterDeploymentGVR).Namespace("certman-operator").Update(ctx, &certRequest, metav1.UpdateOptions{})
+				if err != nil {
+					logger.Error(err, "Error updating CertificateRequest with new owner reference")
+					return false
+				}
+
+				logger.Info("Successfully added ClusterDeployment as the OwnerReference.")
+			}
+
+			for _, owner := range certRequest.GetOwnerReferences() {
+				if owner.Kind == "ClusterDeployment" && owner.Name == clusterName {
+					logger.Info("ClusterDeployment is now the owner!")
+					return true
+				}
+			}
+
+			return false
+		}, pollingDuration, 30*time.Second).Should(BeTrue(), "ClusterDeployment should be the owner of CertificateRequest")
+
+	})
+
 })


### PR DESCRIPTION
This PR adds an end-to-end test to ensure that the ClusterDeployment is set as the owner of the CertificateRequest in the certman-operator namespace. If the owner reference is missing, it is added automatically and verified.

To run the test case, you need to export two environment variables:
DISABLE_JUNIT_REPORT=false
CLUSTER_NAME=<cluster-name>

Then run the test with the command:
go test -tags=osde2e ./test/e2e -v

