### PR TITLE
SREP-1216: Added E2E Test - Delete the ClusterDeployment

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1762956380
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1763362218
 
 ENV USER_UID=1001 \
     USER_NAME=certman-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1762956380
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1763362218
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/test/e2e/certman_operator_tests.go
+++ b/test/e2e/certman_operator_tests.go
@@ -18,9 +18,10 @@ import (
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -242,8 +243,9 @@ var _ = ginkgo.Describe("Certman Operator", ginkgo.Ordered, ginkgo.ContinueOnFai
 		}
 	})
 
-	ginkgo.It("Delete the Cluster Deployment", func(ctx context.Context) {
-		logger.Info("Test - Delete Cluster Deployment")
+	ginkgo.It("should properly cleanup resources when ClusterDeployment is deleted", func(ctx context.Context) {
+		logger.Info("Test - ClusterDeployment deletion cleanup")
+
 		clusterDeploymentGVR := schema.GroupVersionResource{
 			Group:    "hive.openshift.io",
 			Version:  "v1",
@@ -255,100 +257,147 @@ var _ = ginkgo.Describe("Certman Operator", ginkgo.Ordered, ginkgo.ContinueOnFai
 			Resource: "certificaterequests",
 		}
 
+		var cdName string
+		var cdNamespace string
+
+		ginkgo.By("verifying ClusterDeployment exists with certman-operator finalizer")
 		gomega.Eventually(func() bool {
-			logger.Info("Checking if ClusterDeployment exist or not")
-			cdList, err := dynamicClient.Resource(clusterDeploymentGVR).Namespace("certman-operator").List(ctx, metav1.ListOptions{})
+			listOpts := metav1.ListOptions{
+				LabelSelector: "api.openshift.com/managed=true",
+			}
+			cdList, err := dynamicClient.Resource(clusterDeploymentGVR).Namespace(operatorNS).List(ctx, listOpts)
 			if err != nil {
 				logger.Error(err, "Failed to list ClusterDeployments")
 				return false
 			}
 			if len(cdList.Items) == 0 {
-				logger.Info("No ClusterDeployment found in certman-operator namespace.")
+				logger.Info("No managed ClusterDeployment found in namespace", "namespace", operatorNS)
 				return false
 			}
 
-			cd := cdList.Items[0]
-			cdName := cd.GetName()
-			finalizers := cd.GetFinalizers()
-			logger.Info("Found ClusterDeployment", "name", cdName, "finalizers", finalizers)
+			if len(cdList.Items) > 1 {
+				logger.Info("Warning: Multiple managed ClusterDeployments found, using the first one", "count", len(cdList.Items))
+			}
 
-			hasCertFinalizer := false
+			cd := cdList.Items[0]
+			cdName = cd.GetName()
+			cdNamespace = cd.GetNamespace()
+			finalizers := cd.GetFinalizers()
+			logger.Info("Found ClusterDeployment", "name", cdName, "namespace", cdNamespace, "finalizers", finalizers)
+
 			for _, f := range finalizers {
 				if f == "certificaterequests.certman.managed.openshift.io" {
-					hasCertFinalizer = true
+					return true
+				}
+			}
+			logger.Info("ClusterDeployment does not have the certman finalizer yet", "name", cdName)
+			return false
+		}, pollingDuration, 15*time.Second).Should(gomega.BeTrue(), "ClusterDeployment should exist with certman-operator finalizer")
+
+		ginkgo.By("verifying CertificateRequests exist before deletion")
+		var certRequestNames []string
+		gomega.Eventually(func() bool {
+			crList, err := dynamicClient.Resource(certRequestGVR).Namespace(cdNamespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				logger.Error(err, "Failed to list CertificateRequests")
+				return false
+			}
+			if len(crList.Items) == 0 {
+				logger.Info("No CertificateRequests found yet")
+				return false
+			}
+
+			certRequestNames = []string{}
+			for _, cr := range crList.Items {
+				certRequestNames = append(certRequestNames, cr.GetName())
+			}
+			logger.Info("Found CertificateRequests", "count", len(certRequestNames), "names", certRequestNames)
+			return true
+		}, pollingDuration, 15*time.Second).Should(gomega.BeTrue(), "CertificateRequests should exist before ClusterDeployment deletion")
+
+		ginkgo.By("verifying primary-cert-bundle-secret exists before deletion")
+		gomega.Eventually(func() bool {
+			_, err := clientset.CoreV1().Secrets(cdNamespace).Get(ctx, "primary-cert-bundle-secret", metav1.GetOptions{})
+			if err != nil {
+				logger.Info("primary-cert-bundle-secret not found yet")
+				return false
+			}
+			logger.Info("Found primary-cert-bundle-secret")
+			return true
+		}, pollingDuration, 15*time.Second).Should(gomega.BeTrue(), "primary-cert-bundle-secret should exist before ClusterDeployment deletion")
+
+		ginkgo.By("deleting ClusterDeployment")
+		err := dynamicClient.Resource(clusterDeploymentGVR).Namespace(cdNamespace).Delete(ctx, cdName, metav1.DeleteOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Failed to delete ClusterDeployment")
+		logger.Info("Successfully initiated ClusterDeployment deletion", "name", cdName)
+
+		ginkgo.By("verifying certman-operator finalizer does not block ClusterDeployment deletion")
+		gomega.Eventually(func() bool {
+			cd, err := dynamicClient.Resource(clusterDeploymentGVR).Namespace(cdNamespace).Get(ctx, cdName, metav1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					logger.Info("ClusterDeployment has been deleted")
+					return true
+				}
+				logger.Error(err, "Error getting ClusterDeployment")
+				return false
+			}
+
+			finalizers := cd.GetFinalizers()
+			hasCertmanFinalizer := false
+			for _, f := range finalizers {
+				if f == "certificaterequests.certman.managed.openshift.io" {
+					hasCertmanFinalizer = true
 					break
 				}
 			}
 
-			if !hasCertFinalizer {
-				logger.Info("ClusterDeployment does not have the certman finalizer", "name", cdName)
-				return false
+			if !hasCertmanFinalizer {
+				logger.Info("certman-operator finalizer has been removed from ClusterDeployment")
+				return true
 			}
 
-			logger.Info("Found the specified finalizer. Deleting ClusterDeployment", "name", cdName)
-			err = dynamicClient.Resource(clusterDeploymentGVR).Namespace("certman-operator").Delete(ctx, cdName, metav1.DeleteOptions{})
-			if err != nil {
-				logger.Error(err, "Failed to delete ClusterDeployment", "name", cdName)
-				return false
-			}
+			logger.Info("Waiting for certman-operator to remove its finalizer", "currentFinalizers", finalizers)
+			return false
+		}, pollingDuration, 15*time.Second).Should(gomega.BeTrue(), "certman-operator finalizer should not block ClusterDeployment deletion")
 
-			time.Sleep(2 * time.Second)
-
-			logger.Info("Checking if CertificateRequests are deleted")
-
-			crList, err := dynamicClient.Resource(certRequestGVR).Namespace("certman-operator").List(ctx, metav1.ListOptions{})
+		ginkgo.By("verifying CertificateRequests are deleted when ClusterDeployment is deleted")
+		gomega.Eventually(func() bool {
+			crList, err := dynamicClient.Resource(certRequestGVR).Namespace(cdNamespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				logger.Error(err, "Failed to list CertificateRequests")
 				return false
 			}
 
 			if len(crList.Items) > 0 {
+				remainingCRs := []string{}
 				for _, cr := range crList.Items {
-					crName := cr.GetName()
-					finalizers := cr.GetFinalizers()
-
-					if len(finalizers) > 0 {
-						logger.Info("CertificateRequest not deleted due to finalizers. Removing finalizers", "name", crName)
-						cr.SetFinalizers([]string{})
-						_, err := dynamicClient.Resource(certRequestGVR).Namespace("certman-operator").Update(ctx, &cr, metav1.UpdateOptions{})
-						if err != nil {
-							logger.Error(err, "Failed to remove finalizers from CertificateRequest", "name", crName)
-							return false
-						}
-
-					}
-
-					logger.Info("Rechecking CertificateRequest deletion ", "name", crName)
-					crList, err = dynamicClient.Resource(certRequestGVR).Namespace("certman-operator").List(ctx, metav1.ListOptions{})
-					if err != nil {
-						logger.Error(err, "Failed to re-list CertificateRequests")
-						return false
-					}
-					if len(crList.Items) > 0 {
-						logger.Info("CertificateRequests still present")
-						return false
-					}
+					remainingCRs = append(remainingCRs, cr.GetName())
 				}
-			}
-
-			logger.Info("All CertificateRequests successfully deleted")
-
-			logger.Info("Checking if primary-cert-bundle-secret is deleted or not")
-
-			secretList, err := clientset.CoreV1().Secrets("certman-operator").List(ctx, metav1.ListOptions{})
-			if err != nil {
-				logger.Error(err, "Failed to list Secrets in certman-operator")
+				logger.Info("CertificateRequests still present, waiting for cleanup", "remaining", remainingCRs)
 				return false
 			}
-			for _, s := range secretList.Items {
-				if s.Name == "primary-cert-bundle-secret" {
-					ginkgo.Fail("primary-cert-bundle-secret still exists.")
-				}
-			}
-			logger.Info("primary-cert-bundle-secret successfully deleted")
 
+			logger.Info("All CertificateRequests have been deleted")
 			return true
-		}, pollingDuration, 15*time.Second).Should(gomega.BeTrue(), "Delete the Cluster Deployment")
+		}, pollingDuration, 15*time.Second).Should(gomega.BeTrue(), "CertificateRequests should be deleted when ClusterDeployment is deleted")
+
+		ginkgo.By("verifying primary-cert-bundle-secret is deleted when ClusterDeployment is deleted")
+		gomega.Eventually(func() bool {
+			_, err := clientset.CoreV1().Secrets(cdNamespace).Get(ctx, "primary-cert-bundle-secret", metav1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					logger.Info("primary-cert-bundle-secret has been deleted")
+					return true
+				}
+				logger.Error(err, "Error checking for primary-cert-bundle-secret")
+				return false
+			}
+			logger.Info("primary-cert-bundle-secret still exists, waiting for cleanup")
+			return false
+		}, pollingDuration, 15*time.Second).Should(gomega.BeTrue(), "primary-cert-bundle-secret should be deleted when ClusterDeployment is deleted")
+
+		logger.Info("ClusterDeployment deletion cleanup test completed successfully")
 	})
 
 	ginkgo.AfterAll(func(ctx context.Context) {


### PR DESCRIPTION
This PR ensures that deleting a ClusterDeployment with the finalizer certificaterequests.certman.managed.openshift.io automatically deletes the associated CertificateRequest and primary-cert-bundle-secret. The deletion process has been verified to work as expected.

To run the test case, you need to export the below environment variable:
DISABLE_JUNIT_REPORT=false

To run the test:
go test -tags=osde2e ./test/e2e -v
