### PR TITLE
SREP-100 add flags to prevent stuck subscription for certman-operator

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 const (
-	OperatorName      string = "certman-operator"
-	OperatorNamespace string = "certman-operator"
+	OperatorName       string = "certman-operator"
+	OperatorNamespace  string = "certman-operator"
+	EnableOLMSkipRange string = "true"
 )

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -34,7 +34,8 @@ objects:
     name: certman-operator-og
   spec:
     targetNamespaces:
-    - certman-operator
+      - certman-operator
+    upgradeStrategy: TechPreviewUnsafeFailForward 
 
 - apiVersion: operators.coreos.com/v1alpha1
   kind: Subscription


### PR DESCRIPTION
Add EnableOLMSkipRange and upgradeStrategy: TechPreviewUnsafeFailForward in certman-operator to prevent stuck subscription which blocks certman-operator rollout in HIVE