### PR TITLE
.tekton/*: bump rpms-signature-scan task

### DIFF
--- a/.tekton/certman-operator-pull-request.yaml
+++ b/.tekton/certman-operator-pull-request.yaml
@@ -590,7 +590,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:b5c2ba8b26e882dd4cfd396032e00898a557be59a79151a05e60c91dfc44bc5a
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/certman-operator-push.yaml
+++ b/.tekton/certman-operator-push.yaml
@@ -587,7 +587,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:b5c2ba8b26e882dd4cfd396032e00898a557be59a79151a05e60c91dfc44bc5a
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
```
✕ [Violation] trusted_task.trusted
  ImageRef: quay.io/redhat-user-workloads/certman-operator-tenant/openshift/certman-operator@sha256:55bee398fa369cd35b43f964f280010f5db861c63e6ca35f8c65b08b820a9373
  Reason: Untrusted version of PipelineTask "rpms-signature-scan" (Task "rpms-signature-scan") was included in build chain
  comprised of: rpms-signature-scan. Please upgrade the task version to:
  sha256:b5c2ba8b26e882dd4cfd396032e00898a557be59a79151a05e60c91dfc44bc5a
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>
