### PR TITLE
SREP-1223: Add e2e test to verify OwnerReference removal and automatic re-addition on CertificateRequest

### DIFF
--- a/test/e2e/certman_operator_tests.go
+++ b/test/e2e/certman_operator_tests.go
@@ -6,6 +6,7 @@ package osde2etests
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,16 +14,22 @@ import (
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var _ = Describe("Certman Operator", Ordered, func() {
 	var (
-		k8s        *openshift.Client
-		clientset  *kubernetes.Clientset
-		secretName string
+		k8s           *openshift.Client
+		clientset     *kubernetes.Clientset
+		secretName    string
+		dynamicClient dynamic.Interface
 	)
+
 	const (
 		pollingDuration = 15 * time.Minute
 		namespace       = "openshift-config"
@@ -35,6 +42,8 @@ var _ = Describe("Certman Operator", Ordered, func() {
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to setup k8s client")
 		clientset, err = kubernetes.NewForConfig(k8s.GetConfig())
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to setup Config client")
+		dynamicClient, err = dynamic.NewForConfig(k8s.GetConfig())
+		Expect(err).ShouldNot(HaveOccurred(), "Unable to setup dynamic client")
 	})
 
 	It("certificate secret exists under openshift-config namespace", func(ctx context.Context) {
@@ -61,5 +70,69 @@ var _ = Describe("Certman Operator", Ordered, func() {
 			}
 			return apiserver.Spec.ServingCerts.NamedCertificates[0].ServingCertificate.Name == secretName
 		}, pollingDuration, 30*time.Second).Should(BeTrue(), "Certificate secret should be applied to apiserver object")
+	})
+
+	It("removes OwnerReference by simulating oc apply -f with modified file using server-side apply", func(ctx context.Context) {
+		logger := log.FromContext(ctx)
+		certRequestGVR := schema.GroupVersionResource{
+			Group:    "certman.managed.openshift.io",
+			Version:  "v1alpha1",
+			Resource: "certificaterequests",
+		}
+		crNamespace := "certman-operator"
+
+		Eventually(func() bool {
+			crList, err := dynamicClient.Resource(certRequestGVR).Namespace(crNamespace).List(ctx, metav1.ListOptions{})
+			if err != nil || len(crList.Items) == 0 {
+				logger.Error(err, "Failed to list CertificateRequests")
+				return false
+			}
+
+			originalCR := crList.Items[0]
+			crName := originalCR.GetName()
+			logger.Info("Fetched CertificateRequest", "name", crName, "resourceVersion", originalCR.GetResourceVersion())
+
+			unstructured.RemoveNestedField(originalCR.Object, "metadata", "ownerReferences")
+			unstructured.RemoveNestedField(originalCR.Object, "metadata", "managedFields")
+
+			if _, found, _ := unstructured.NestedFieldNoCopy(originalCR.Object, "metadata", "ownerReferences"); found {
+				logger.Info("ownerReferences still present after removal attempt", "name", crName)
+			} else {
+				logger.Info("ownerReferences removed before patch", "name", crName)
+			}
+
+			patchBytes, err := json.Marshal(originalCR.Object)
+			if err != nil {
+				logger.Error(err, "Failed to marshal modified CertificateRequest", "name", crName)
+				return false
+			}
+
+			patchedCR, err := dynamicClient.Resource(certRequestGVR).Namespace(crNamespace).Patch(ctx, crName, types.ApplyPatchType, patchBytes, metav1.PatchOptions{
+				FieldManager: "certman-e2e-test",
+			})
+			if err != nil {
+				logger.Error(err, "Failed to apply patch", "name", crName)
+				return false
+			}
+			logger.Info("Patch applied", "name", crName, "newResourceVersion", patchedCR.GetResourceVersion())
+
+			time.Sleep(10 * time.Second)
+
+			finalCR, err := dynamicClient.Resource(certRequestGVR).Namespace(crNamespace).Get(ctx, crName, metav1.GetOptions{})
+			if err != nil {
+				logger.Error(err, "Failed to get CertificateRequest after patch", "name", crName)
+				return false
+			}
+			logger.Info("Fetched final CertificateRequest", "name", crName, "resourceVersion", finalCR.GetResourceVersion())
+
+			for _, ref := range finalCR.GetOwnerReferences() {
+				if ref.Controller != nil && *ref.Controller {
+					logger.Info("OwnerReference re-added", "name", crName)
+					return true
+				}
+			}
+			logger.Info("OwnerReference not re-added yet", "name", crName)
+			return false
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue(), "OwnerReference should be re-added after patch")
 	})
 })


### PR DESCRIPTION
This e2e test simulates the removal of the OwnerReference from a CertificateRequest resource in the certman-operator 

namespace using server-side apply.

It verifies that the OwnerReference is automatically re-added by the operator controller after patching, ensuring proper 

owner lifecycle management.