### PR TITLE
SREP-4381: Requeue when cluster not yet installed to speed up cert delivery

### DIFF
--- a/controllers/clusterdeployment/clusterdeployment_controller.go
+++ b/controllers/clusterdeployment/clusterdeployment_controller.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -114,8 +115,8 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, request rec
 
 	//Do not reconcile if cluster is not installed
 	if !cd.Spec.Installed {
-		reqLogger.Info(fmt.Sprintf("cluster %v is not yet in installed state", cd.Name))
-		return reconcile.Result{}, nil
+		reqLogger.Info(fmt.Sprintf("cluster %v is not yet in installed state, will recheck in 30s", cd.Name))
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	// Do not reconcile if the cluster is being relocated


### PR DESCRIPTION
## Summary

When a new ClusterDeployment is created with `Installed=false`, the controller returns `reconcile.Result{}` without requeuing. It relies on the default 10-minute controller-runtime resync or a watch event to notice when Hive sets `Installed=true`.

This adds a `RequeueAfter: 30s` so the controller actively polls for the installed state instead of waiting for the resync cycle. This should reduce cert delivery time from 30-35 minutes to cluster install time + ~30 seconds.

## Problem

certman-operator on hive-stage-01 takes 30-35 minutes to deliver Let's Encrypt certs to newly provisioned clusters. Investigation showed the ACME flow itself is fast (~4 seconds), but there's a gap between cluster install completion and when certman-operator starts processing the CertificateRequest.

Timing data from hive-stage-01 (2026-04-07):
- ci-rosa-s-ugqb: cluster created 15:24, cert issued 15:58 (34 min)
- osde2e-s2e56: cluster created 16:34, cert issued 17:06 (32 min)

This slow cert delivery is the primary contributor to ROSA Classic STS CI job failures, where the `osd-cluster-ready` health check requires certs to be present.

## Test plan

- [x] Unit tests pass
- [x] Build succeeds
- [ ] Verify reduced cert delivery time on staging after deploy

Jira: https://redhat.atlassian.net/browse/SREP-4381