### PR TITLE
fix: ensure FEDRAMP env var is passed to operator deployment through PKO template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,14 @@
 # =============================================================================
 #
 # INSTALL
-#   pip install pre-commit
-#   pre-commit install
+#   For detailed setup instructions including uv (recommended) and pip,
+#   see: boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+#
+#   Quick start (uv):
+#     uv sync && source .venv/bin/activate && pre-commit install
+#
+#   Quick start (pip):
+#     pip install 'pre-commit==4.6.0' && pre-commit install
 #
 # USAGE
 #   pre-commit run              # staged files only (developer / agent workflow)
@@ -34,6 +40,9 @@
 #   Auto-fix hooks (trailing-whitespace, end-of-file-fixer) will correct
 #   pre-existing violations on the first run. Stage and commit those fixes
 #   separately before day-to-day use.
+#
+#   Fix commits can be excluded from git blame
+#   https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile
 #
 # =============================================================================
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,10 +5,11 @@
 aliases:
   srep-functional-team-aurora:
     - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
-    - luis-falcon
     - reedcort
   srep-functional-team-fedramp:
     - theautoroboto

--- a/boilerplate/_data/last-boilerplate-commit
+++ b/boilerplate/_data/last-boilerplate-commit
@@ -1,1 +1,1 @@
-61dbfdfcfd8ab11f8ccbd58bf1d299c2fa3336dd
+7df87310d42bac5efb374ed0ca9aceb86076b108

--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -5,10 +5,11 @@
 aliases:
   srep-functional-team-aurora:
     - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
-    - luis-falcon
     - reedcort
   srep-functional-team-fedramp:
     - theautoroboto

--- a/boilerplate/openshift/golang-osd-operator/dependabot.yml
+++ b/boilerplate/openshift/golang-osd-operator/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "lgtm"
+      - "approved"
     schedule:
       interval: "weekly"
     ignore:

--- a/boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+++ b/boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
@@ -1,0 +1,123 @@
+# Pre-Commit Hooks Setup Guide
+
+## Installation
+
+### Recommended: Using uv
+
+[uv](https://github.com/astral-sh/uv) is recommended for Python dependency management. It provides dependency locking with package hashes (supply-chain protection), virtual environment management, and is 10-100x faster than pip.
+
+**Install uv:**
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# Via pip
+pip install uv
+```
+
+**First-time setup:**
+```bash
+uv init --bare                    # creates pyproject.toml
+uv add --dev pre-commit==4.6.0    # adds dependency, generates uv.lock
+source .venv/bin/activate         # macOS/Linux (.venv\Scripts\activate on Windows)
+pre-commit install
+```
+
+**Subsequent setup** (when `pyproject.toml` and `uv.lock` exist):
+```bash
+uv sync
+source .venv/bin/activate
+pre-commit install
+```
+
+### Alternative: Using pip
+
+```bash
+pip install 'pre-commit==4.6.0'   # pinned version (Golden Rule 15)
+pre-commit install
+```
+
+Add to `requirements-dev.txt`: `pre-commit==4.6.0`
+
+## First-Time Setup
+
+Run on all files to catch existing issues:
+```bash
+pre-commit run --all-files
+```
+
+Auto-fix hooks will modify files on first run. Stage and commit these separately:
+```bash
+git diff
+git add .
+git commit -m "Fix: Apply pre-commit auto-fixes"
+```
+
+**Exclude fix commits from git blame:**
+```bash
+# Create .git-blame-ignore-revs with commit hashes
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+See [git-blame docs](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile).
+
+## Usage
+
+**Automatic** (runs on `git commit`):
+```bash
+git add <files>
+git commit -m "Message"
+```
+
+**Manual:**
+```bash
+pre-commit run                              # staged files only
+pre-commit run --all-files                  # entire repo
+pre-commit run --files path/to/file         # specific files
+```
+
+**Bypass (use sparingly):**
+```bash
+SKIP=hook-id git commit -m "Message"        # skip one hook
+git commit --no-verify                      # NEVER use (Golden Rule 16)
+```
+
+Rules: Agents never bypass hooks. Security hooks (gitleaks) never bypassable.
+
+## Troubleshooting
+
+**macOS timeout issues:**
+```bash
+brew install coreutils  # provides gtimeout
+```
+
+**Virtual environment not found:**
+```bash
+source .venv/bin/activate
+uv sync
+```
+
+**Hooks not running:**
+```bash
+ls -la .git/hooks/pre-commit  # verify installation
+pre-commit install            # reinstall
+```
+
+**Hook failures:** Read error messages and fix issues:
+- `go-build`: Fix compilation errors
+- `go-mod-tidy`: Run `go mod tidy` and stage go.mod/go.sum
+- `check-yaml`: Fix YAML syntax
+
+## CI Integration
+
+Pre-commit mirrors `ci/prow/lint`. CI is authoritative; pre-commit is developer convenience. All hooks run in CI with same config.
+
+If pre-commit passes but CI fails: `pre-commit autoupdate`
+
+## Resources
+
+- [Pre-Commit Documentation](https://pre-commit.com/)
+- [uv Documentation](https://github.com/astral-sh/uv)

--- a/boilerplate/openshift/golang-osd-operator/olm_pko_migration.py
+++ b/boilerplate/openshift/golang-osd-operator/olm_pko_migration.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import yaml
 
@@ -629,7 +629,7 @@ def write_pko_dockerfile():
             )
         )
 
-def extract_deployment_selector() -> str | None:
+def extract_deployment_selector() -> Optional[str]:
     """
     Extract the clusterDeploymentSelector from hack/olm-registry/olm-artifacts-template.yaml.
 

--- a/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
+++ b/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
@@ -4,8 +4,14 @@
 # =============================================================================
 #
 # INSTALL
-#   pip install pre-commit
-#   pre-commit install
+#   For detailed setup instructions including uv (recommended) and pip,
+#   see: boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+#
+#   Quick start (uv):
+#     uv sync && source .venv/bin/activate && pre-commit install
+#
+#   Quick start (pip):
+#     pip install 'pre-commit==4.6.0' && pre-commit install
 #
 # USAGE
 #   pre-commit run              # staged files only (developer / agent workflow)
@@ -34,6 +40,9 @@
 #   Auto-fix hooks (trailing-whitespace, end-of-file-fixer) will correct
 #   pre-existing violations on the first run. Stage and commit those fixes
 #   separately before day-to-day use.
+#
+#   Fix commits can be excluded from git blame
+#   https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile
 #
 # =============================================================================
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
 
 ENV USER_UID=1001 \
     USER_NAME=certman-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy_pko/.dockerignore
+++ b/deploy_pko/.dockerignore
@@ -1,0 +1,1 @@
+.test-fixtures

--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -1,0 +1,103 @@
+---
+# This Job cleans up old OLM resources after migrating to PKO
+# IMPORTANT: Review and customize this template before deploying!
+# 
+# Things to customize:
+# 1. Adjust the namespace if needed
+# 2. Modify resource filters (CSV names, labels, etc.)
+# 3. Review RBAC permissions
+# 4. Update the cleanup logic for your specific operator
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  # CUSTOMIZE: Adjust permissions as needed for your cleanup tasks
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - operatorgroups
+      - catalogsources
+    verbs:
+      - list
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: certman-operator
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+              # CUSTOMIZE: Update the label selector for your operator
+              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
+              oc -n certman-operator delete csv -l "operators.coreos.com/certman-operator.certman-operator" --ignore-not-found=true
+              
+              # Delete subscriptions
+              oc -n certman-operator delete subscription certman-operator --ignore-not-found=true
+              
+              # Delete operatorgroup
+              oc -n certman-operator delete operatorgroups certman-operator-og --ignore-not-found=true
+
+              # Delete catalogsource
+              oc -n certman-operator delete catalogsources certman-operator-catalog --ignore-not-found=true
+
+              # - Clean up custom resources
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/default/ClusterRole-certman-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-certman-operator.yaml
@@ -1,0 +1,108 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - certman.managed.openshift.io
+  resources:
+  - '*'
+  - certificaterequests
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/finalizers
+  - clusterdeployments/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aws.managed.openshift.io
+  resources:
+  - accountclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - dnszones
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-certman-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-certman-operator.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: certman-operator
+  namespace: certman-operator
+roleRef:
+  kind: ClusterRole
+  name: certman-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/default/CustomResourceDefinition-certificaterequests.certman.managed.openshift.io.yaml
+++ b/deploy_pko/.test-fixtures/default/CustomResourceDefinition-certificaterequests.certman.managed.openshift.io.yaml
@@ -1,0 +1,344 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: certificaterequests.certman.managed.openshift.io
+spec:
+  group: certman.managed.openshift.io
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    singular: certificaterequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.issuerName
+      name: IssuerName
+      type: string
+    - jsonPath: .status.notBefore
+      name: NotBefore
+      type: string
+    - jsonPath: .status.notAfter
+      name: NotAfter
+      type: string
+    - jsonPath: .spec.certificateSecret.name
+      name: Secret
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CertificateRequest is the Schema for the certificaterequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateRequestSpec defines the desired state of CertificateRequest
+            properties:
+              acmeDNSDomain:
+                description: 'ACMEDNSDomain is the DNS zone that will house the TXT
+                  records needed for the
+
+                  certificate to be created.
+
+                  In Route53 this would be the public Route53 hosted zone (the Domain
+                  Name not the ZoneID)'
+                type: string
+              apiURL:
+                description: APIURL is the URL where the cluster's API can be accessed.
+                type: string
+              certificateSecret:
+                description: CertificateSecret is the reference to the secret where
+                  certificates are stored.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string
+
+                      should contain a valid JSON/Go field access statement, such
+                      as desiredState.manifest.containers[2].
+
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like:
+
+                      "spec.containers{name}" (where "name" refers to the name of
+                      the container that triggered
+
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with
+
+                      index 2 in this pod). This syntax is chosen only to have some
+                      well-defined way of
+
+                      referencing a part of an object.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent.
+
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent.
+
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent.
+
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any.
+
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent.
+
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                items:
+                  type: string
+                type: array
+              email:
+                description: Let's Encrypt will use this to contact you about expiring
+                  certificates, and issues related to your account.
+                type: string
+              platform:
+                description: Platform contains specific cloud provider information
+                  such as credentials and secrets for the cluster infrastructure.
+                properties:
+                  aws:
+                    description: AWSPlatformSecrets contains secrets for clusters
+                      on the AWS platform.
+                    properties:
+                      credentials:
+                        description: 'Credentials refers to a secret that contains
+                          the AWS account access
+
+                          credentials.'
+                        properties:
+                          name:
+                            default: ''
+                            description: 'Name of the referent.
+
+                              This field is effectively required, but due to backwards
+                              compatibility is
+
+                              allowed to be empty. Instances of this type with an
+                              empty value here are
+
+                              almost certainly wrong.
+
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      region:
+                        description: Region specifies the AWS region where the cluster
+                          will be created.
+                        type: string
+                    required:
+                    - credentials
+                    - region
+                    type: object
+                  azure:
+                    description: AzurePlatformSecrets contains secrets for clusters
+                      on the Azure platform.
+                    properties:
+                      credentials:
+                        description: Credentials refers to a secret that contains
+                          the AZURE account access credentials.
+                        properties:
+                          name:
+                            default: ''
+                            description: 'Name of the referent.
+
+                              This field is effectively required, but due to backwards
+                              compatibility is
+
+                              allowed to be empty. Instances of this type with an
+                              empty value here are
+
+                              almost certainly wrong.
+
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      resourceGroupName:
+                        description: ResourceGroupName refers to the resource group
+                          that contains the dns zone.
+                        type: string
+                    required:
+                    - credentials
+                    - resourceGroupName
+                    type: object
+                  gcp:
+                    description: GCPPlatformSecrets contains secrets for clusters
+                      on the GCP platform.
+                    properties:
+                      credentials:
+                        description: 'Credentials refers to a secret that contains
+                          the GCP account access
+
+                          credentials.'
+                        properties:
+                          name:
+                            default: ''
+                            description: 'Name of the referent.
+
+                              This field is effectively required, but due to backwards
+                              compatibility is
+
+                              allowed to be empty. Instances of this type with an
+                              empty value here are
+
+                              almost certainly wrong.
+
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - credentials
+                    type: object
+                  mock:
+                    description: 'MockPlatformSecrets indicates a mock client should
+                      be generated, which
+
+                      doesn''t interact with any platform'
+                    properties:
+                      answerDNSChallengeErrorString:
+                        type: string
+                      answerDNSChallengeFQDN:
+                        description: these options configure the return values for
+                          the mock client's functions
+                        type: string
+                      deleteAcmeChallengeResourceRecordsErrorString:
+                        type: string
+                      validateDNSWriteAccessBool:
+                        type: boolean
+                      validateDNSWriteAccessErrorString:
+                        type: string
+                    type: object
+                type: object
+              renewBeforeDays:
+                description: 'Number of days before expiration to reissue certificate.
+
+                  NOTE: Keeping "renew" in JSON for backward-compatibility.'
+                type: integer
+              webConsoleURL:
+                description: WebConsoleURL is the URL for the cluster's web console
+                  UI.
+                type: string
+            required:
+            - acmeDNSDomain
+            - certificateSecret
+            - dnsNames
+            - email
+            - platform
+            type: object
+          status:
+            description: CertificateRequestStatus defines the observed state of CertificateRequest
+            properties:
+              conditions:
+                description: Conditions includes more detailed status for the Certificate
+                  Request
+                items:
+                  description: CertificateRequestCondition defines conditions required
+                    for certificate requests.
+                  properties:
+                    lastProbeTime:
+                      description: LastProbeTime is the last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about last transition.
+                      type: string
+                    reason:
+                      description: Reason is a unique, one-word, CamelCase reason
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              issued:
+                description: Issued is true once certificates have been issued.
+                type: boolean
+              issuerName:
+                description: The entity that verified the information and signed the
+                  certificate.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                type: string
+              notBefore:
+                description: The earliest time and date on which the certificate stored
+                  in the secret named by this resource in spec.secretName is valid.
+                type: string
+              serialNumber:
+                description: The serial number of the certificate stored in the secret
+                  named by this resource in spec.secretName.
+                type: string
+              status:
+                description: Status
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/.test-fixtures/default/Deployment-certman-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/Deployment-certman-operator.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: certman-operator
       containers:
       - name: certman-operator
-        image: '{{ .config.image }}'
+        image: 'certman-operator:latest'
         resources:
           requests:
             cpu: 100m
@@ -42,6 +42,6 @@ spec:
         - name: EXTRA_RECORD
           value: rh-api
         - name: FEDRAMP
-          value: '{{ .config.fedramp }}'
+          value: 'false'
         - name: HOSTED_ZONE_ID
-          value: '{{ .config.hosted_zone_id }}'
+          value: ''

--- a/deploy_pko/.test-fixtures/default/Role-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/default/Role-prometheus-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/default/RoleBinding-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/default/RoleBinding-prometheus-k8s.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/default/ServiceAccount-certman-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ServiceAccount-certman-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: certman-operator
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -1,0 +1,103 @@
+---
+# This Job cleans up old OLM resources after migrating to PKO
+# IMPORTANT: Review and customize this template before deploying!
+# 
+# Things to customize:
+# 1. Adjust the namespace if needed
+# 2. Modify resource filters (CSV names, labels, etc.)
+# 3. Review RBAC permissions
+# 4. Update the cleanup logic for your specific operator
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  # CUSTOMIZE: Adjust permissions as needed for your cleanup tasks
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - operatorgroups
+      - catalogsources
+    verbs:
+      - list
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: certman-operator
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+              # CUSTOMIZE: Update the label selector for your operator
+              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
+              oc -n certman-operator delete csv -l "operators.coreos.com/certman-operator.certman-operator" --ignore-not-found=true
+              
+              # Delete subscriptions
+              oc -n certman-operator delete subscription certman-operator --ignore-not-found=true
+              
+              # Delete operatorgroup
+              oc -n certman-operator delete operatorgroups certman-operator-og --ignore-not-found=true
+
+              # Delete catalogsource
+              oc -n certman-operator delete catalogsources certman-operator-catalog --ignore-not-found=true
+
+              # - Clean up custom resources
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-certman-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-certman-operator.yaml
@@ -1,0 +1,108 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - certman.managed.openshift.io
+  resources:
+  - '*'
+  - certificaterequests
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterdeployments/finalizers
+  - clusterdeployments/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aws.managed.openshift.io
+  resources:
+  - accountclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - dnszones
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-certman-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-certman-operator.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: certman-operator
+  namespace: certman-operator
+roleRef:
+  kind: ClusterRole
+  name: certman-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/fedramp/CustomResourceDefinition-certificaterequests.certman.managed.openshift.io.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/CustomResourceDefinition-certificaterequests.certman.managed.openshift.io.yaml
@@ -1,0 +1,344 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    package-operator.run/phase: crds
+    package-operator.run/collision-protection: IfNoController
+  name: certificaterequests.certman.managed.openshift.io
+spec:
+  group: certman.managed.openshift.io
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    singular: certificaterequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.issuerName
+      name: IssuerName
+      type: string
+    - jsonPath: .status.notBefore
+      name: NotBefore
+      type: string
+    - jsonPath: .status.notAfter
+      name: NotAfter
+      type: string
+    - jsonPath: .spec.certificateSecret.name
+      name: Secret
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CertificateRequest is the Schema for the certificaterequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateRequestSpec defines the desired state of CertificateRequest
+            properties:
+              acmeDNSDomain:
+                description: 'ACMEDNSDomain is the DNS zone that will house the TXT
+                  records needed for the
+
+                  certificate to be created.
+
+                  In Route53 this would be the public Route53 hosted zone (the Domain
+                  Name not the ZoneID)'
+                type: string
+              apiURL:
+                description: APIURL is the URL where the cluster's API can be accessed.
+                type: string
+              certificateSecret:
+                description: CertificateSecret is the reference to the secret where
+                  certificates are stored.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string
+
+                      should contain a valid JSON/Go field access statement, such
+                      as desiredState.manifest.containers[2].
+
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like:
+
+                      "spec.containers{name}" (where "name" refers to the name of
+                      the container that triggered
+
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with
+
+                      index 2 in this pod). This syntax is chosen only to have some
+                      well-defined way of
+
+                      referencing a part of an object.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent.
+
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent.
+
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent.
+
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any.
+
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent.
+
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                items:
+                  type: string
+                type: array
+              email:
+                description: Let's Encrypt will use this to contact you about expiring
+                  certificates, and issues related to your account.
+                type: string
+              platform:
+                description: Platform contains specific cloud provider information
+                  such as credentials and secrets for the cluster infrastructure.
+                properties:
+                  aws:
+                    description: AWSPlatformSecrets contains secrets for clusters
+                      on the AWS platform.
+                    properties:
+                      credentials:
+                        description: 'Credentials refers to a secret that contains
+                          the AWS account access
+
+                          credentials.'
+                        properties:
+                          name:
+                            default: ''
+                            description: 'Name of the referent.
+
+                              This field is effectively required, but due to backwards
+                              compatibility is
+
+                              allowed to be empty. Instances of this type with an
+                              empty value here are
+
+                              almost certainly wrong.
+
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      region:
+                        description: Region specifies the AWS region where the cluster
+                          will be created.
+                        type: string
+                    required:
+                    - credentials
+                    - region
+                    type: object
+                  azure:
+                    description: AzurePlatformSecrets contains secrets for clusters
+                      on the Azure platform.
+                    properties:
+                      credentials:
+                        description: Credentials refers to a secret that contains
+                          the AZURE account access credentials.
+                        properties:
+                          name:
+                            default: ''
+                            description: 'Name of the referent.
+
+                              This field is effectively required, but due to backwards
+                              compatibility is
+
+                              allowed to be empty. Instances of this type with an
+                              empty value here are
+
+                              almost certainly wrong.
+
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      resourceGroupName:
+                        description: ResourceGroupName refers to the resource group
+                          that contains the dns zone.
+                        type: string
+                    required:
+                    - credentials
+                    - resourceGroupName
+                    type: object
+                  gcp:
+                    description: GCPPlatformSecrets contains secrets for clusters
+                      on the GCP platform.
+                    properties:
+                      credentials:
+                        description: 'Credentials refers to a secret that contains
+                          the GCP account access
+
+                          credentials.'
+                        properties:
+                          name:
+                            default: ''
+                            description: 'Name of the referent.
+
+                              This field is effectively required, but due to backwards
+                              compatibility is
+
+                              allowed to be empty. Instances of this type with an
+                              empty value here are
+
+                              almost certainly wrong.
+
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - credentials
+                    type: object
+                  mock:
+                    description: 'MockPlatformSecrets indicates a mock client should
+                      be generated, which
+
+                      doesn''t interact with any platform'
+                    properties:
+                      answerDNSChallengeErrorString:
+                        type: string
+                      answerDNSChallengeFQDN:
+                        description: these options configure the return values for
+                          the mock client's functions
+                        type: string
+                      deleteAcmeChallengeResourceRecordsErrorString:
+                        type: string
+                      validateDNSWriteAccessBool:
+                        type: boolean
+                      validateDNSWriteAccessErrorString:
+                        type: string
+                    type: object
+                type: object
+              renewBeforeDays:
+                description: 'Number of days before expiration to reissue certificate.
+
+                  NOTE: Keeping "renew" in JSON for backward-compatibility.'
+                type: integer
+              webConsoleURL:
+                description: WebConsoleURL is the URL for the cluster's web console
+                  UI.
+                type: string
+            required:
+            - acmeDNSDomain
+            - certificateSecret
+            - dnsNames
+            - email
+            - platform
+            type: object
+          status:
+            description: CertificateRequestStatus defines the observed state of CertificateRequest
+            properties:
+              conditions:
+                description: Conditions includes more detailed status for the Certificate
+                  Request
+                items:
+                  description: CertificateRequestCondition defines conditions required
+                    for certificate requests.
+                  properties:
+                    lastProbeTime:
+                      description: LastProbeTime is the last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about last transition.
+                      type: string
+                    reason:
+                      description: Reason is a unique, one-word, CamelCase reason
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              issued:
+                description: Issued is true once certificates have been issued.
+                type: boolean
+              issuerName:
+                description: The entity that verified the information and signed the
+                  certificate.
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                type: string
+              notBefore:
+                description: The earliest time and date on which the certificate stored
+                  in the secret named by this resource in spec.secretName is valid.
+                type: string
+              serialNumber:
+                description: The serial number of the certificate stored in the secret
+                  named by this resource in spec.secretName.
+                type: string
+              status:
+                description: Status
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy_pko/.test-fixtures/fedramp/Deployment-certman-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Deployment-certman-operator.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: certman-operator
       containers:
       - name: certman-operator
-        image: '{{ .config.image }}'
+        image: 'certman-operator:latest'
         resources:
           requests:
             cpu: 100m
@@ -42,6 +42,6 @@ spec:
         - name: EXTRA_RECORD
           value: rh-api
         - name: FEDRAMP
-          value: '{{ .config.fedramp }}'
+          value: 'true'
         - name: HOSTED_ZONE_ID
-          value: '{{ .config.hosted_zone_id }}'
+          value: 'Z0123456789ABCDEFGHIJ'

--- a/deploy_pko/.test-fixtures/fedramp/Role-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Role-prometheus-k8s.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/fedramp/RoleBinding-prometheus-k8s.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/RoleBinding-prometheus-k8s.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/ServiceAccount-certman-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ServiceAccount-certman-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: certman-operator
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -32,3 +32,34 @@ spec:
           description: Operator image to deploy
           type: string
           default: None
+        fedramp:
+          description: Enable FedRAMP mode
+          type: string
+          default: "false"
+          enum:
+          - "true"
+          - "false"
+        hosted_zone_id:
+          description: Hosted zone ID for FedRAMP DNS operations
+          type: string
+          default: ""
+test:
+  template:
+  - name: default
+    context:
+      package:
+        metadata:
+          name: certman-operator
+          namespace: certman-operator
+      config:
+        image: certman-operator:latest
+  - name: fedramp
+    context:
+      package:
+        metadata:
+          name: certman-operator
+          namespace: certman-operator
+      config:
+        image: certman-operator:latest
+        fedramp: "true"
+        hosted_zone_id: Z0123456789ABCDEFGHIJ

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -14,6 +14,8 @@ parameters:
     required: true
   - name: FEDRAMP
     value: "false"
+  - name: HOSTED_ZONE_ID
+    value: ""
 metadata:
   name: clusterpackage-template
 objects:
@@ -27,6 +29,5 @@ objects:
       image: ${PKO_IMAGE}:${IMAGE_TAG}
       config:
         image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
-        env:
-        - name: FEDRAMP
-          value: "${FEDRAMP}"
+        fedramp: "${FEDRAMP}"
+        hosted_zone_id: "${HOSTED_ZONE_ID}"


### PR DESCRIPTION
### Summary

Properly passed `FEDRAMP` env var through PKO template to operator deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable FedRAMP option for operator deployments with a hosted zone setting and wiring to deployment templates.

* **Tests**
  * Added a FedRAMP test variant to exercise the new configuration.

* **Chores**
  * Updated pre-commit guidance and pinned install instruction.
  * Improved Docker build ignore patterns.
  * Updated team ownership aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->