### PR TITLE
fix: propagate FEDRAMP and HOSTED_ZONE_ID from ClusterPackage config into operator Deployment

### DIFF
--- a/deploy_pko/Deployment-certman-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-certman-operator.yaml.gotmpl
@@ -41,7 +41,7 @@ spec:
           value: certman-operator
         - name: EXTRA_RECORD
           value: rh-api
-        - name: FEDRAMP
-          value: 'false'
-        - name: HOSTED_ZONE_ID
-          value: ''
+{{- range .config.env }}
+        - name: {{ .name }}
+          value: {{ .value | quote }}
+{{- end }}

--- a/deploy_pko/Deployment-certman-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-certman-operator.yaml.gotmpl
@@ -41,7 +41,7 @@ spec:
           value: certman-operator
         - name: EXTRA_RECORD
           value: rh-api
-{{- range .config.env }}
-        - name: {{ .name }}
-          value: {{ .value | quote }}
-{{- end }}
+        - name: FEDRAMP
+          value: {{ .config.fedramp | quote }}
+        - name: HOSTED_ZONE_ID
+          value: {{ .config.hostedZoneId | quote }}

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -32,16 +32,11 @@ spec:
           description: Operator image to deploy
           type: string
           default: None
-        env:
-          description: Additional environment variables injected into the operator container
-          type: array
-          items:
-            type: object
-            required:
-            - name
-            - value
-            properties:
-              name:
-                type: string
-              value:
-                type: string
+        fedramp:
+          description: Whether the operator runs in a FedRAMP environment
+          type: string
+          default: "false"
+        hostedZoneId:
+          description: Route53 hosted zone ID for FedRAMP DNS operations
+          type: string
+          default: ""

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -32,3 +32,16 @@ spec:
           description: Operator image to deploy
           type: string
           default: None
+        env:
+          description: Additional environment variables injected into the operator container
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - value
+            properties:
+              name:
+                type: string
+              value:
+                type: string

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -36,6 +36,9 @@ spec:
           description: Whether the operator runs in a FedRAMP environment
           type: string
           default: "false"
+          enum:
+            - "true"
+            - "false"
         hostedZoneId:
           description: Route53 hosted zone ID for FedRAMP DNS operations
           type: string

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -14,6 +14,8 @@ parameters:
     required: true
   - name: FEDRAMP
     value: "false"
+  - name: HOSTED_ZONE_ID
+    value: ""
 metadata:
   name: clusterpackage-template
 objects:
@@ -30,3 +32,5 @@ objects:
         env:
         - name: FEDRAMP
           value: "${FEDRAMP}"
+        - name: HOSTED_ZONE_ID
+          value: "${HOSTED_ZONE_ID}"

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -29,8 +29,5 @@ objects:
       image: ${PKO_IMAGE}:${IMAGE_TAG}
       config:
         image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
-        env:
-        - name: FEDRAMP
-          value: "${FEDRAMP}"
-        - name: HOSTED_ZONE_ID
-          value: "${HOSTED_ZONE_ID}"
+        fedramp: "${FEDRAMP}"
+        hostedZoneId: "${HOSTED_ZONE_ID}"


### PR DESCRIPTION
## Summary

The PKO deployment template has `FEDRAMP` hardcoded to `'false'`, ignoring the value provided via `ClusterPackage.spec.config`. This means FedRAMP deployments never receive `FEDRAMP=true` despite the ClusterPackage CR containing the correct value.

This PR also fixes `HOSTED_ZONE_ID`, which has the same class of bug but was not previously surfaced because `FEDRAMP` was always `false` — the operator only reads `HOSTED_ZONE_ID` when `FEDRAMP=true` ([certificaterequest_controller.go L89-94](https://github.com/openshift/certman-operator/blob/master/controllers/certificaterequest/certificaterequest_controller.go#L89-L94)). Once `FEDRAMP` propagation is fixed, the operator would immediately fail if `HOSTED_ZONE_ID` remained hardcoded to `''`. Additionally, `HOSTED_ZONE_ID` was never wired into the PKO clusterpackage template at all — a regression from the OLM path (`olm-artifacts-template.yaml`), which passed both variables.

### Issues this PR intends to fix

Two issues in the PKO config propagation chain:

1. **`deploy_pko/manifest.yaml`** — The `openAPIV3Schema` only declares `image` as a config property. PKO uses this schema for [validation and pruning](https://package-operator.run/docs/api_reference/package-operator-api/). Any config fields not declared in the schema are silently pruned before template rendering, so they never reach the `.gotmpl` context.

2. **`deploy_pko/Deployment-certman-operator.yaml.gotmpl`** — `FEDRAMP` and `HOSTED_ZONE_ID` are hardcoded in the env block rather than reading from `.config`, unlike `image` which correctly uses `{{ .config.image }}`.

Additionally, `hack/pko/clusterpackage.yaml` was missing `HOSTED_ZONE_ID` entirely — it was never declared as a template parameter or included in `spec.config`, so the values passed at deploy time were silently dropped.

### Changes introduced by this PR

| File | Change |
|------|--------|
| `deploy_pko/manifest.yaml` | Add `fedramp` (string, default `"false"`, constrained to `"true"`/`"false"` via enum) and `hostedZoneId` (string, default `""`) to `openAPIV3Schema` so PKO preserves them instead of pruning. The enum prevents typos like `"True"` or `"yes"` from silently disabling FedRAMP mode, since the runtime check uses an exact `"true"` match. |
| `hack/pko/clusterpackage.yaml` | Add `HOSTED_ZONE_ID` as a Template parameter. Pass `fedramp` and `hostedZoneId` as named config properties, matching the pattern used for `image`. |
| `deploy_pko/Deployment-certman-operator.yaml.gotmpl` | Replace hardcoded `FEDRAMP` and `HOSTED_ZONE_ID` values with `{{ .config.fedramp \| quote }}` and `{{ .config.hostedZoneId \| quote }}`, matching the pattern already used for `{{ .config.image }}`. |

### Data flow after fix

```
ClusterPackage spec.config
  fedramp: "true"
  hostedZoneId: "..."
        │
        ▼
PKO reads manifest.yaml openAPIV3Schema
  fedramp and hostedZoneId declared → NOT pruned
        │
        ▼
PKO renders Deployment-certman-operator.yaml.gotmpl
  {{ .config.fedramp | quote }}      → "true"
  {{ .config.hostedZoneId | quote }} → "..."
        │
        ▼
Operator pod starts with correct FEDRAMP and HOSTED_ZONE_ID values
```

### Non-regression Notes

Non-FedRAMP deployments do not set `FEDRAMP` or `HOSTED_ZONE_ID`, so the schema defaults apply (`"false"` and `""`). The operator only checks `HOSTED_ZONE_ID` when `FEDRAMP=true`, so behavior for non-FedRAMP clusters is unchanged.