### PR TITLE
ROSA-745: Pilot MintMaker gomod batching config (temporary)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>openshift/boilerplate//.github/renovate.json"
+    "github>openshift/boilerplate#chore/renovate-gomod-daily-batch//.github/renovate.json"
   ]
 }


### PR DESCRIPTION
## Summary

Temporary pilot to validate [openshift/boilerplate#746](https://github.com/openshift/boilerplate/pull/746) before it merges.

Points `.github/renovate.json` at the boilerplate PR branch so MintMaker picks up grouped gomod updates and the UTC weekday schedule.

**Revert or restore `extends` → `openshift/boilerplate` on `master` after the pilot.**

## Test plan

- [ ] MintMaker opens **one** grouped gomod PR (not many per-module PRs)
- [ ] Grouped PR activity falls in **UTC 02:00–04:59, Mon–Fri** (or note if the run was outside the window)
- [ ] Tide auto-merges after **required** checks are green with `lgtm`/`approved` on the PR (no manual `/lgtm` `/approve`)
- [ ] A failing **required** check blocks merge
- [ ] Revert this change after sign-off; merge boilerplate #746 for fleet rollout

## Rollback

Restore:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
    "github>openshift/boilerplate//.github/renovate.json"
  ]
}
```


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated upstream dependency management configuration to use a different boilerplate baseline for automated updates. This changes which standard configuration is inherited for dependency automation, aligning the repository with the new baseline and its update cadence and rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->