### PR TITLE
Prefer cross-signed LE chain for backwards compatibility

### DIFF
--- a/controllers/certificaterequest/issue_certificate.go
+++ b/controllers/certificaterequest/issue_certificate.go
@@ -182,7 +182,7 @@ func (r *CertificateRequestReconciler) IssueCertificate(reqLogger logr.Logger, c
 
 	reqLogger.Info("fetching certificates")
 
-	certs, err := leClient.FetchCertificates()
+	certs, err := fetchPreferredChain(reqLogger, leClient)
 	if err != nil {
 		return err
 	}
@@ -220,6 +220,39 @@ func (r *CertificateRequestReconciler) IssueCertificate(reqLogger logr.Logger, c
 	}
 
 	return nil
+}
+
+// fetchPreferredChain fetches all available certificate chains and selects
+// the one cross-signed by a widely-trusted root (ISRG Root X1). This ensures
+// backwards compatibility with trust stores that don't yet include newer
+// roots. Falls back to the default chain if no cross-signed alternative
+// is available.
+func fetchPreferredChain(reqLogger logr.Logger, leClient leclient.LetsEncryptClientInterface) ([]*x509.Certificate, error) {
+	const preferredIssuerCN = "ISRG Root X1"
+
+	allChains, err := leClient.FetchAllCertificates()
+	if err != nil {
+		reqLogger.Info("could not fetch alternate chains, falling back to default", "error", err)
+		return leClient.FetchCertificates()
+	}
+
+	for chainURL, chain := range allChains {
+		if len(chain) < 2 {
+			continue
+		}
+		root := chain[len(chain)-1]
+		if root.Issuer.CommonName == preferredIssuerCN {
+			reqLogger.Info("selected cross-signed certificate chain",
+				"chainURL", chainURL,
+				"rootSubject", root.Subject.CommonName,
+				"rootIssuer", root.Issuer.CommonName,
+			)
+			return chain, nil
+		}
+	}
+
+	reqLogger.Info("no cross-signed chain found, using default chain")
+	return leClient.FetchCertificates()
 }
 
 func (r *CertificateRequestReconciler) FindZoneIDForChallenge(namespace string, dnsClient cClient.Client) (string, error) {

--- a/controllers/certificaterequest/issue_certificate_test.go
+++ b/controllers/certificaterequest/issue_certificate_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eggsampler/acme"
+	"github.com/eggsampler/acme/v3"
 	"github.com/go-logr/logr"
 	dnschallenge "github.com/openshift/certman-operator/pkg/clients/mock"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
+	github.com/eggsampler/acme/v3 v3.8.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/eggsampler/acme v1.0.0 h1:sVHToytaPbCfxwbTzPcCGfe2ibs78Rh0Pt+cQzEXc0g=
 github.com/eggsampler/acme v1.0.0/go.mod h1:8WmHqL9DowF/uQ1AmTfPM7VeVGbhg/urRmS+vb2WlS4=
+github.com/eggsampler/acme/v3 v3.8.1 h1:HmpFs/CIdEXg2NCwSEFBd1BgSzzN8fPzwNZGzp0izrw=
+github.com/eggsampler/acme/v3 v3.8.1/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/pkg/acmeclient/acmeclient.go
+++ b/pkg/acmeclient/acmeclient.go
@@ -4,7 +4,7 @@ import (
 	"crypto"
 	"crypto/x509"
 
-	"github.com/eggsampler/acme"
+	"github.com/eggsampler/acme/v3"
 )
 
 // the real acme client is github.com/eggsampler/acme
@@ -20,6 +20,7 @@ type AcmeClientInterface interface {
 	//Directory() acme.Directory
 	FetchAuthorization(acme.Account, string) (acme.Authorization, error)
 	FetchCertificates(acme.Account, string) ([]*x509.Certificate, error)
+	FetchAllCertificates(acme.Account, string) (map[string][]*x509.Certificate, error)
 	//FetchChallenge(acme.Account, string) (acme.Challenge, error)
 	//FetchOrder(acme.Account, string) (acme.Order, error)
 	FinalizeOrder(acme.Account, acme.Order, *x509.CertificateRequest) (acme.Order, error)
@@ -27,6 +28,6 @@ type AcmeClientInterface interface {
 	NewOrder(acme.Account, []acme.Identifier) (acme.Order, error)
 	//NewOrderDomains(acme.Account, ...string) (acme.Order, error)
 	RevokeCertificate(acme.Account, *x509.Certificate, crypto.Signer, int) error
-	UpdateAccount(acme.Account, bool, ...string) (acme.Account, error)
+	UpdateAccount(acme.Account, ...string) (acme.Account, error)
 	UpdateChallenge(acme.Account, acme.Challenge) (acme.Challenge, error)
 }

--- a/pkg/acmeclient/mock/mock.go
+++ b/pkg/acmeclient/mock/mock.go
@@ -6,7 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 
-	"github.com/eggsampler/acme"
+	"github.com/eggsampler/acme/v3"
 )
 
 type FakeAcmeClient struct {
@@ -57,7 +57,7 @@ func NewFakeAcmeClient(opts *FakeAcmeClientOptions) (fac *FakeAcmeClient) {
 	return
 }
 
-func (fac *FakeAcmeClient) UpdateAccount(account acme.Account, tosAgreed bool, contacts ...string) (rAccount acme.Account, err error) {
+func (fac *FakeAcmeClient) UpdateAccount(account acme.Account, contacts ...string) (rAccount acme.Account, err error) {
 	// track if this was called
 	fac.UpdateAccountCalled = true
 	fac.Contacts = contacts
@@ -116,6 +116,14 @@ VoZplnP9BdVECzSa
 	}
 
 	return
+}
+
+func (fac *FakeAcmeClient) FetchAllCertificates(account acme.Account, certificateURL string) (map[string][]*x509.Certificate, error) {
+	certs, err := fac.FetchCertificates(account, certificateURL)
+	if err != nil {
+		return nil, err
+	}
+	return map[string][]*x509.Certificate{certificateURL: certs}, nil
 }
 
 func (fac *FakeAcmeClient) FinalizeOrder(acme.Account, acme.Order, *x509.CertificateRequest) (order acme.Order, err error) {

--- a/pkg/acmeclient/mock/mock_test.go
+++ b/pkg/acmeclient/mock/mock_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/eggsampler/acme"
+	"github.com/eggsampler/acme/v3"
 )
 
 func TestNewFakeAcmeClient(t *testing.T) {
@@ -100,7 +100,7 @@ func TestUpdateAccount(t *testing.T) {
 			mockAcmeClient := NewFakeAcmeClient(test.Options)
 
 			// there's no account to update, so that return value is dropped
-			_, err := mockAcmeClient.UpdateAccount(acme.Account{}, true, "email@domain.tld")
+			_, err := mockAcmeClient.UpdateAccount(acme.Account{}, "email@domain.tld")
 			if err != nil {
 				if !test.ExpectError {
 					t.Errorf("UpdateAccount() %s: got unexpected error \"%s\"\n", test.Name, err)

--- a/pkg/leclient/lets_encrypt.go
+++ b/pkg/leclient/lets_encrypt.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/eggsampler/acme"
+	"github.com/eggsampler/acme/v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/certman-operator/config"
@@ -49,6 +49,7 @@ type LetsEncryptClientInterface interface {
 	FinalizeOrder(*x509.CertificateRequest) error
 	GetOrderEndpoint() string
 	FetchCertificates() ([]*x509.Certificate, error)
+	FetchAllCertificates() (map[string][]*x509.Certificate, error)
 	RevokeCertificate(*x509.Certificate) error
 }
 
@@ -69,7 +70,7 @@ func (c *LetsEncryptClient) UpdateAccount(email string) (err error) {
 		contacts = []string{fmt.Sprintf("mailto:%s", email)}
 	}
 
-	account, err := c.Client.UpdateAccount(c.Account, true, contacts...)
+	account, err := c.Client.UpdateAccount(c.Account, contacts...)
 	if err != nil {
 		return err
 	}
@@ -177,6 +178,12 @@ func (c *LetsEncryptClient) GetOrderEndpoint() string {
 func (c *LetsEncryptClient) FetchCertificates() (certbundle []*x509.Certificate, err error) {
 	certbundle, err = c.Client.FetchCertificates(c.Account, c.Order.Certificate)
 	return certbundle, err
+}
+
+// FetchAllCertificates fetches the default certificate chain and any alternate
+// chains offered by the ACME server via Link rel="alternate" headers.
+func (c *LetsEncryptClient) FetchAllCertificates() (map[string][]*x509.Certificate, error) {
+	return c.Client.FetchAllCertificates(c.Account, c.Order.Certificate)
 }
 
 // RevokeCertificate accepts x509.Certificate as certificate and calls the acme RevokeCertificate

--- a/pkg/leclient/lets_encrypt_test.go
+++ b/pkg/leclient/lets_encrypt_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/eggsampler/acme"
+	"github.com/eggsampler/acme/v3"
 	"github.com/openshift/certman-operator/config"
 	acmemock "github.com/openshift/certman-operator/pkg/acmeclient/mock"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -6,7 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 
-	"github.com/eggsampler/acme"
+	"github.com/eggsampler/acme/v3"
 )
 
 type FakeAcmeClient struct {

--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/eggsampler/acme"
+	"github.com/eggsampler/acme/v3"
 )
 
 func TestNewFakeAcmeClient(t *testing.T) {


### PR DESCRIPTION
## Summary

- Upgrade eggsampler/acme from v1 to v3 to use `FetchAllCertificates()`
- Dynamically select the cross-signed certificate chain when alternate chains are available from the ACME server
- No hardcoded certs: chain selection is based on root issuer CN matching `ISRG Root X1`
- Falls back to the default chain if no cross-signed alternative is available

## Problem

On May 13 2026, Let's Encrypt switched the default ACME profile to issue from Gen Y chains. Certs renewed after this date have the chain:

```
Leaf -> YR1 (Gen Y intermediate) -> Root YR (Gen Y root, self-signed)
```

Root YR is not in RHEL/UBI trust stores (only ISRG Root X1 and X2 are present). This causes Hive, backplane-api, and other Go TLS clients to reject the cert with `x509: certificate signed by unknown authority`.

## Fix

The ACME protocol provides alternate chains via `Link: rel="alternate"` response headers. Let's Encrypt serves a cross-signed chain as an alternate. With eggsampler/acme v3, `FetchAllCertificates()` retrieves both the default and alternate chains. The code selects the chain whose root is signed by `ISRG Root X1`:

```
Leaf -> YR1 -> Root YR (cross-signed by ISRG Root X1)
```

This approach is maintainable because:
- No hardcoded certificates that expire and need code updates
- Chain selection is dynamic based on what the ACME server offers
- If LE changes their chain hierarchy again, the code adapts as long as a cross-signed chain exists
- Graceful fallback to the default chain if no preferred chain is found

## Changes

- `pkg/acmeclient/acmeclient.go`: Add `FetchAllCertificates` to interface
- `pkg/leclient/lets_encrypt.go`: Add `FetchAllCertificates` wrapper + update interface
- `controllers/certificaterequest/issue_certificate.go`: `fetchPreferredChain()` selects cross-signed chain
- `pkg/acmeclient/mock/mock.go`: Mock implementation
- All files: Update eggsampler/acme import from v1 to v3 (v3 `UpdateAccount` dropped `tosAgreed` param)

## Incident

[ITN-2026-00169](https://web-rca.devshift.net/incident/ITN-2026-00169)

## Testing

- All unit tests pass
- Verified with `openssl s_client` that the cross-signed chain validates against ISRG Root X1
- Confirmed affected cluster (`tzrosa-j3dvf6mj`) serves the Gen Y chain and fails validation with X1-only trust store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ACME library dependency to version 3
  * Improved certificate chain selection during issuance to prioritize chains meeting specific issuer requirements with automatic fallback to default behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->