### PR TITLE
Include full certificate chain in TLS secret

### DIFF
--- a/controllers/certificaterequest/issue_certificate.go
+++ b/controllers/certificaterequest/issue_certificate.go
@@ -206,7 +206,7 @@ func (r *CertificateRequestReconciler) IssueCertificate(reqLogger logr.Logger, c
 	}
 
 	certificateSecret.Data = map[string][]byte{
-		corev1.TLSCertKey:       []byte(pemData[0] + pemData[1]), // create fullchain
+		corev1.TLSCertKey:       []byte(strings.Join(pemData, "")),
 		corev1.TLSPrivateKeyKey: key,
 	}
 


### PR DESCRIPTION
## Summary

One-line fix: change `pemData[0] + pemData[1]` to `strings.Join(pemData, "")` so the full certificate chain is included in the TLS secret.

## Problem

PR #475 added cross-signed chain selection, but the fullchain assembly was hardcoded to only concatenate the first two certs. When the cross-signed chain has three certs (leaf + YR1 intermediate + cross-signed Root YR), the third cert was dropped. Clients couldn't build a trust path back to ISRG Root X1.

## Fix

```go
// Before:
corev1.TLSCertKey: []byte(pemData[0] + pemData[1])

// After:
corev1.TLSCertKey: []byte(strings.Join(pemData, ""))
```

## Incident

[ITN-2026-00169](https://web-rca.devshift.net/incident/ITN-2026-00169)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed certificate chain assembly to properly handle certificate chains with variable numbers of certificates, improving compatibility across different certificate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->