### PR TITLE
Use classic ACME profile to issue Gen X certificates

### DIFF
--- a/pkg/acmeclient/acmeclient.go
+++ b/pkg/acmeclient/acmeclient.go
@@ -26,6 +26,7 @@ type AcmeClientInterface interface {
 	FinalizeOrder(acme.Account, acme.Order, *x509.CertificateRequest) (acme.Order, error)
 	//NewAccount(crypto.Signer, bool, bool, ...string) (acme.Account, error)
 	NewOrder(acme.Account, []acme.Identifier) (acme.Order, error)
+	NewOrderExtension(acme.Account, []acme.Identifier, acme.OrderExtension) (acme.Order, error)
 	//NewOrderDomains(acme.Account, ...string) (acme.Order, error)
 	RevokeCertificate(acme.Account, *x509.Certificate, crypto.Signer, int) error
 	UpdateAccount(acme.Account, ...string) (acme.Account, error)

--- a/pkg/acmeclient/mock/mock.go
+++ b/pkg/acmeclient/mock/mock.go
@@ -19,13 +19,15 @@ type FakeAcmeClient struct {
 	Contacts    []string
 	Identifiers []acme.Identifier
 
-	FetchAuthorizationCalled bool
-	FetchCertificatesCalled  bool
-	FinalizeOrderCalled      bool
-	NewOrderCalled           bool
-	RevokeCertificateCalled  bool
-	UpdateAccountCalled      bool
-	UpdateChallengeCalled    bool
+	FetchAuthorizationCalled    bool
+	FetchCertificatesCalled     bool
+	FinalizeOrderCalled         bool
+	NewOrderCalled              bool
+	NewOrderExtensionCalled     bool
+	NewOrderExtensionProfile    string
+	RevokeCertificateCalled     bool
+	UpdateAccountCalled         bool
+	UpdateChallengeCalled       bool
 }
 
 type FakeAcmeClientOptions struct {
@@ -148,6 +150,12 @@ func (fac *FakeAcmeClient) NewOrder(a acme.Account, ids []acme.Identifier) (orde
 	}
 
 	return
+}
+
+func (fac *FakeAcmeClient) NewOrderExtension(a acme.Account, ids []acme.Identifier, ext acme.OrderExtension) (order acme.Order, err error) {
+	fac.NewOrderExtensionCalled = true
+	fac.NewOrderExtensionProfile = ext.Profile
+	return fac.NewOrder(a, ids)
 }
 
 func (fac *FakeAcmeClient) RevokeCertificate(acme.Account, *x509.Certificate, crypto.Signer, int) (err error) {

--- a/pkg/leclient/lets_encrypt.go
+++ b/pkg/leclient/lets_encrypt.go
@@ -88,7 +88,9 @@ func (c *LetsEncryptClient) CreateOrder(domains []string) (err error) {
 	for _, domain := range domains {
 		ids = append(ids, acme.Identifier{Type: "dns", Value: domain})
 	}
-	c.Order, err = c.Client.NewOrder(c.Account, ids)
+	c.Order, err = c.Client.NewOrderExtension(c.Account, ids, acme.OrderExtension{
+		Profile: "classic",
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/leclient/lets_encrypt_test.go
+++ b/pkg/leclient/lets_encrypt_test.go
@@ -211,8 +211,11 @@ func TestCreateOrder(t *testing.T) {
 				if test.ExpectError {
 					t.Errorf("CreateOrder() %s: expected error \"%s\" but didn't get one\n", test.Name, test.ExpectedErrorString)
 				}
-				if !test.ACME.NewOrderCalled {
-					t.Errorf("CreateOrder() %s: expected the acme client NewOrder() to be called but it wasn't\n", test.Name)
+				if !test.ACME.NewOrderExtensionCalled {
+					t.Errorf("CreateOrder() %s: expected the acme client NewOrderExtension() to be called but it wasn't\n", test.Name)
+				}
+				if test.ACME.NewOrderExtensionProfile != "classic" {
+					t.Errorf("CreateOrder() %s: expected ACME profile \"classic\", got %q\n", test.Name, test.ACME.NewOrderExtensionProfile)
 				}
 			}
 


### PR DESCRIPTION
## Summary

Request the `classic` ACME profile when creating LE orders so certificates are issued from the Gen X hierarchy (R11/E7 under ISRG Root X1), which is trusted by all current RHEL/UBI trust stores.

## Problem

PR #475 attempted to select a cross-signed alternate chain via `FetchAllCertificates`, but LE does not serve a cross-signed chain as an ACME alternate for Gen Y orders. The `fetchPreferredChain` function found no matching chain and fell back to the default Gen Y chain. Clusters continued to get certs signed by YR1/YR2 under Root YR.

## Fix

```go
// Before (NewOrder uses LE's default profile, which is now Gen Y):
c.Order, err = c.Client.NewOrder(c.Account, ids)

// After (request classic profile to get Gen X certs):
c.Order, err = c.Client.NewOrderExtension(c.Account, ids, acme.OrderExtension{
    Profile: "classic",
})
```

LE advertises `classic` as a supported profile in their ACME directory. The classic profile issues from the Gen X hierarchy (R11/E7 intermediates under ISRG Root X1) which is universally trusted.

## Changes

- `pkg/leclient/lets_encrypt.go`: Use `NewOrderExtension` with `Profile: "classic"`
- `pkg/acmeclient/acmeclient.go`: Add `NewOrderExtension` to interface
- `pkg/acmeclient/mock/mock.go`: Mock with profile tracking
- `pkg/leclient/lets_encrypt_test.go`: Verify `NewOrderExtension` is called with `classic` profile

## Incident

[ITN-2026-00169](https://web-rca.devshift.net/incident/ITN-2026-00169)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ACME order extensions, allowing configuration of certificate order profiles during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->