### PR TITLE
Use classic ACME profile and include full certificate chain

### DIFF
--- a/controllers/certificaterequest/issue_certificate.go
+++ b/controllers/certificaterequest/issue_certificate.go
@@ -206,7 +206,7 @@ func (r *CertificateRequestReconciler) IssueCertificate(reqLogger logr.Logger, c
 	}
 
 	certificateSecret.Data = map[string][]byte{
-		corev1.TLSCertKey:       []byte(pemData[0] + pemData[1]), // create fullchain
+		corev1.TLSCertKey:       []byte(strings.Join(pemData, "")),
 		corev1.TLSPrivateKeyKey: key,
 	}
 

--- a/pkg/acmeclient/acmeclient.go
+++ b/pkg/acmeclient/acmeclient.go
@@ -26,6 +26,7 @@ type AcmeClientInterface interface {
 	FinalizeOrder(acme.Account, acme.Order, *x509.CertificateRequest) (acme.Order, error)
 	//NewAccount(crypto.Signer, bool, bool, ...string) (acme.Account, error)
 	NewOrder(acme.Account, []acme.Identifier) (acme.Order, error)
+	NewOrderExtension(acme.Account, []acme.Identifier, acme.OrderExtension) (acme.Order, error)
 	//NewOrderDomains(acme.Account, ...string) (acme.Order, error)
 	RevokeCertificate(acme.Account, *x509.Certificate, crypto.Signer, int) error
 	UpdateAccount(acme.Account, ...string) (acme.Account, error)

--- a/pkg/acmeclient/mock/mock.go
+++ b/pkg/acmeclient/mock/mock.go
@@ -19,13 +19,15 @@ type FakeAcmeClient struct {
 	Contacts    []string
 	Identifiers []acme.Identifier
 
-	FetchAuthorizationCalled bool
-	FetchCertificatesCalled  bool
-	FinalizeOrderCalled      bool
-	NewOrderCalled           bool
-	RevokeCertificateCalled  bool
-	UpdateAccountCalled      bool
-	UpdateChallengeCalled    bool
+	FetchAuthorizationCalled    bool
+	FetchCertificatesCalled     bool
+	FinalizeOrderCalled         bool
+	NewOrderCalled              bool
+	NewOrderExtensionCalled     bool
+	NewOrderExtensionProfile    string
+	RevokeCertificateCalled     bool
+	UpdateAccountCalled         bool
+	UpdateChallengeCalled       bool
 }
 
 type FakeAcmeClientOptions struct {
@@ -116,6 +118,12 @@ VoZplnP9BdVECzSa
 	}
 
 	return
+}
+
+func (fac *FakeAcmeClient) NewOrderExtension(a acme.Account, ids []acme.Identifier, ext acme.OrderExtension) (order acme.Order, err error) {
+	fac.NewOrderExtensionCalled = true
+	fac.NewOrderExtensionProfile = ext.Profile
+	return fac.NewOrder(a, ids)
 }
 
 func (fac *FakeAcmeClient) FetchAllCertificates(account acme.Account, certificateURL string) (map[string][]*x509.Certificate, error) {

--- a/pkg/leclient/lets_encrypt.go
+++ b/pkg/leclient/lets_encrypt.go
@@ -88,7 +88,9 @@ func (c *LetsEncryptClient) CreateOrder(domains []string) (err error) {
 	for _, domain := range domains {
 		ids = append(ids, acme.Identifier{Type: "dns", Value: domain})
 	}
-	c.Order, err = c.Client.NewOrder(c.Account, ids)
+	c.Order, err = c.Client.NewOrderExtension(c.Account, ids, acme.OrderExtension{
+		Profile: "classic",
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/leclient/lets_encrypt_test.go
+++ b/pkg/leclient/lets_encrypt_test.go
@@ -211,8 +211,11 @@ func TestCreateOrder(t *testing.T) {
 				if test.ExpectError {
 					t.Errorf("CreateOrder() %s: expected error \"%s\" but didn't get one\n", test.Name, test.ExpectedErrorString)
 				}
-				if !test.ACME.NewOrderCalled {
-					t.Errorf("CreateOrder() %s: expected the acme client NewOrder() to be called but it wasn't\n", test.Name)
+				if !test.ACME.NewOrderExtensionCalled {
+					t.Errorf("CreateOrder() %s: expected NewOrderExtension() to be called but it wasn't\n", test.Name)
+				}
+				if test.ACME.NewOrderExtensionProfile != "classic" {
+					t.Errorf("CreateOrder() %s: expected ACME profile \"classic\", got %q\n", test.Name, test.ACME.NewOrderExtensionProfile)
 				}
 			}
 


### PR DESCRIPTION
## Summary

Two fixes for the LE Gen Y certificate trust failure, consolidated from #476 and #477.

1. **Classic ACME profile**: Use `NewOrderExtension` with `Profile: "classic"` so LE includes the cross-signed Root YR cert (signed by ISRG Root X1) in the chain
2. **Full chain assembly**: Use `strings.Join(pemData, "")` instead of `pemData[0] + pemData[1]` so all certs (including the cross-signed root) make it into the TLS secret

Both fixes are required. The classic profile returns a 3-cert chain, and the old `pemData[0]+pemData[1]` drops the third cert.

## Validation

Tested end-to-end against LE production using an integration cluster domain with RSA-2048 (matching certman-operator):

```
=== Certificate Chain (3 certs) ===
   Cert 0: subject=acme-validate.itn-2026-00169.6rmg.i1.devshift.org  issuer=YR1
   Cert 1: subject=YR1  issuer=Root YR
   Cert 2: subject=Root YR  issuer=ISRG Root X1

=== Validation against ISRG Root X1 trust store ===
   BUGGY (pemData[0]+pemData[1], 2 certs): FAIL - error 20: unable to get local issuer certificate
   FIXED (strings.Join, all certs):        OK
```

## Changes

- `pkg/acmeclient/acmeclient.go`: Add `NewOrderExtension` to interface
- `pkg/leclient/lets_encrypt.go`: Use `NewOrderExtension` with `Profile: "classic"`
- `controllers/certificaterequest/issue_certificate.go`: `strings.Join(pemData, "")` for fullchain
- `pkg/acmeclient/mock/mock.go`: Mock with profile tracking
- `pkg/leclient/lets_encrypt_test.go`: Assert classic profile is requested

## Incident

[ITN-2026-00169](https://web-rca.devshift.net/incident/ITN-2026-00169)

Supersedes #476 and #477.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate chain storage now captures the complete certificate chain in Kubernetes Secrets, ensuring all certificates are preserved.

* **New Features**
  * ACME order creation has been extended to support profile-based configuration options, enabling more flexible certificate provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->