### PR TITLE
[ROSAENG-61300] restore minimal RBAC for legacy leader election

### DIFF
--- a/deploy/role_leader_election.yaml
+++ b/deploy/role_leader_election.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: certman-operator-leader-election
+  namespace: certman-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - certman-operator-lock
+  verbs:
+  - get
+  - create
+  - delete

--- a/deploy/role_leader_election.yaml
+++ b/deploy/role_leader_election.yaml
@@ -21,3 +21,14 @@ rules:
   - get
   - create
   - delete
+# certman-operator is the long-lived (5+ years) default-config ConfigMap read by
+# GetDefaultNotificationEmailAddress (controllers/utils/utils.go), on the hot path of every
+# ClusterDeployment reconcile that has a CertificateBundle with Generate: true.
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - certman-operator
+  verbs:
+  - get

--- a/deploy/rolebinding_leader_election.yaml
+++ b/deploy/rolebinding_leader_election.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: certman-operator-leader-election
+  namespace: certman-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: certman-operator-leader-election
+subjects:
+- kind: ServiceAccount
+  name: certman-operator
+  namespace: certman-operator

--- a/deploy_pko/Role-leader-election.yaml
+++ b/deploy_pko/Role-leader-election.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: certman-operator-leader-election
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - certman-operator-lock
+  verbs:
+  - get
+  - create
+  - delete

--- a/deploy_pko/Role-leader-election.yaml
+++ b/deploy_pko/Role-leader-election.yaml
@@ -24,3 +24,14 @@ rules:
   - get
   - create
   - delete
+# certman-operator is the long-lived (5+ years) default-config ConfigMap read by
+# GetDefaultNotificationEmailAddress (controllers/utils/utils.go), on the hot path of every
+# ClusterDeployment reconcile that has a CertificateBundle with Generate: true.
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - certman-operator
+  verbs:
+  - get

--- a/deploy_pko/RoleBinding-leader-election.yaml
+++ b/deploy_pko/RoleBinding-leader-election.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: certman-operator-leader-election
+  namespace: certman-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: certman-operator-leader-election
+subjects:
+- kind: ServiceAccount
+  name: certman-operator
+  namespace: certman-operator


### PR DESCRIPTION
fe224153 ([ROSAENG-61300](https://redhat.atlassian.net/browse/ROSAENG-61300)'s RBAC tightening) dropped the certman-operator ClusterRole's cluster-wide pods and configmaps access entirely, but main.go still calls the legacy operator-lib leader.Become(), which needs to Get its own Pod (to build the lock ConfigMap's ownerRef) and Get/Create a "certman-operator-lock" ConfigMap in its own namespace. Without this, the operator pod crash-loops on every startup with:

  "pods \"<pod>\" is forbidden: ... cannot get resource \"pods\" ..."

Confirmed live on hivei01ue1 (co-hivei01ue1 tracks ref: master, so it deployed this the moment PR #505 merged): certman-operator pod has been CrashLoopBackOff for 3+ days with 899 restarts, and the periodic-ci-openshift-certman-operator-master-hive-e2e-promotion-int Prow job has failed twice as a result, blocking the entire int -> stage -> canary promotion chain for [ROSAENG-61300](https://redhat.atlassian.net/browse/ROSAENG-61300).

Fix: add a namespaced Role/RoleBinding (OLM deploy/ and PKO deploy_pko/) scoped to the certman-operator namespace only, mirroring the aws-account-operator Role/RoleBinding pattern from 991dea5a:
- pods: get, delete (own namespace only, not cluster-wide)
- configmaps: get, create, delete, restricted via resourceNames to the single "certman-operator-lock" object leader.Become() manages

This is still strictly least-privilege versus the original wildcard ClusterRole -- scoped to one namespace and, for configmaps, one named object -- it just accounts for a permission leader.Become() needs that the original ticket's pkg/ grep didn't cover (main.go isn't under pkg/, and the call is in a vendored library).

[ROSAENG-61300]: https://redhat.atlassian.net/browse/ROSAENG-61300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61300]: https://redhat.atlassian.net/browse/ROSAENG-61300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator leader-election reliability by granting the required permissions to manage election locks and inspect relevant pods.
  * Applied the permissions consistently across supported deployment configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->