### PR TITLE
ROSAENG-61837: Restore pods/configmaps RBAC for leader election

### DIFF
--- a/deploy_pko/ClusterRole-certman-operator.yaml
+++ b/deploy_pko/ClusterRole-certman-operator.yaml
@@ -10,6 +10,20 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ''
+  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
## Summary

PR #505 ([ROSAENG-61300](https://redhat.atlassian.net/browse/ROSAENG-61300) least privilege RBAC) removed `pods` and `configmaps` from the certman-operator ClusterRole. The operator-lib leader election (`leader.Become`) requires:
- `pods` get: to find its own pod for the owner reference
- `configmaps` get/create/update: for the leader lock ConfigMap

The operator is currently **CrashLoopBackOff** on hivei01ue1 with:
```
pods "certman-operator-7f449f6f45-4f497" is forbidden: User "system:serviceaccount:certman-operator:certman-operator" cannot get resource "pods" in API group "" in the namespace "certman-operator"
```

## Urgency

This is blocking all certman-operator functionality on hivei01ue1 (int hive). The operator cannot start.

## Test plan

- [ ] After merge + SAPM promotion, verify certman-operator pod reaches Running/Ready on hivei01ue1

Jira: https://redhat.atlassian.net/browse/ROSAENG-61837

[ROSAENG-61300]: https://redhat.atlassian.net/browse/ROSAENG-61300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ