### PR TITLE
ROSAENG-61837: Add list/watch for configmaps RBAC

### DIFF
--- a/deploy_pko/ClusterRole-certman-operator.yaml
+++ b/deploy_pko/ClusterRole-certman-operator.yaml
@@ -24,6 +24,8 @@ rules:
   - configmaps
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ''
   resources:


### PR DESCRIPTION
## Summary

PR #512 restored `configmaps` get/create/update but missed `list` and `watch`. The controller-runtime cache reflector needs list+watch to sync the configmap informer.

Current operator logs on hivei01ue1:
```
configmaps is forbidden: User "system:serviceaccount:certman-operator:certman-operator"
cannot list resource "configmaps" in API group "" at the cluster scope
```

This is spamming the logs every ~5 seconds and preventing the operator from properly caching and reconciling resources, which causes the hive-e2e promotion tests to time out.

## Urgency

Blocking certman-operator e2e promotion pipeline on hivei01ue1.

## Test plan

- [ ] After merge + SAPM promotion, verify no more `configmaps is forbidden` errors in operator logs on hivei01ue1

Jira: https://redhat.atlassian.net/browse/ROSAENG-61837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate management reliability by enabling the operator to monitor configuration settings more effectively.
  * Reduced the risk of missed configuration updates during certificate-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->